### PR TITLE
Split encrypt and decrypt rekey()

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -596,7 +596,7 @@ impl Conn<Client> {
                 return error::BadUsage.fail();
             }
 
-            self.kex.resume_kexdhreply(&p, s)
+            self.kex.resume_kexdhreply(&p, &mut self.sess_id, s)
         } else {
             Err(Error::bug())
         }
@@ -649,7 +649,13 @@ impl Conn<Server> {
 
         let packet = self.packet(payload)?;
         if let Packet::KexDHInit(p) = packet {
-            self.kex.resume_kexdhinit(&p, self.is_first_kex(), keys, s)
+            self.kex.resume_kexdhinit(
+                &p,
+                self.is_first_kex(),
+                keys,
+                &mut self.sess_id,
+                s,
+            )
         } else {
             Err(Error::bug())
         }

--- a/src/kex.rs
+++ b/src/kex.rs
@@ -39,8 +39,6 @@ use traffic::TrafSend;
 const MAX_SESSID: usize = 32;
 pub type SessId = heapless::Vec<u8, MAX_SESSID>;
 
-use pretty_hex::PrettyHex;
-
 // TODO this will be configurable.
 const fixed_options_kex: &[&str] = &[
     #[cfg(feature = "mlkem")]
@@ -704,7 +702,7 @@ impl SharedSecret {
 
         // TODO: error message on signature failure.
         let h: &[u8] = kex_out.h.as_ref();
-        trace!("verify  h {}", h.hex_dump());
+        trace!("verify  h {h:02x?}");
         algos
             .hostsig
             .verify(&p.k_s.0, &h, &p.sig.0)
@@ -765,7 +763,7 @@ impl SharedSecret {
         let q_s = BinString(kex_pub);
 
         let k_s = Blob(hostkey.pubkey());
-        trace!("sign kexreply h {}", ko.h.as_slice().hex_dump());
+        trace!("sign kexreply h {:02x?}", ko.h.as_slice());
         let sig = hostkey.sign(&ko.h.as_slice())?;
         let sig: Signature = (&sig).into();
         let sig = Blob(sig);

--- a/src/kex.rs
+++ b/src/kex.rs
@@ -528,6 +528,9 @@ impl<CS: CliServ> Kex<CS> {
             trace!("kexdhreply not client");
             return error::SSHProto.fail();
         }
+        if !matches!(self, Kex::KexDH { .. }) {
+            return error::PacketWrong.fail();
+        }
         Ok(DispatchEvent::CliEvent(event::CliEventId::Hostkey))
     }
 
@@ -543,6 +546,8 @@ impl<CS: CliServ> Kex<CS> {
                 // Ignore this packet
                 return Ok(DispatchEvent::None);
             }
+        } else {
+            return error::PacketWrong.fail();
         }
 
         Ok(DispatchEvent::ServEvent(ServEventId::Hostkeys))
@@ -573,7 +578,8 @@ impl Kex<Client> {
             *self = Kex::NewKeys { output, algos };
             Ok(())
         } else {
-            error::PacketWrong.fail()
+            // Already checked in handle_kexdhreply
+            Err(Error::bug())
         }
     }
 }
@@ -599,7 +605,8 @@ impl Kex<Server> {
 
             Ok(())
         } else {
-            error::PacketWrong.fail()
+            // Already checked in handle_kexdhinit
+            Err(Error::bug())
         }
     }
 

--- a/src/ssh_chapoly.rs
+++ b/src/ssh_chapoly.rs
@@ -17,8 +17,6 @@ use poly1305::Poly1305;
 use subtle::ConstantTimeEq;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-use pretty_hex::PrettyHex;
-
 use crate::*;
 use encrypt::SSH_LENGTH_SIZE;
 
@@ -64,7 +62,7 @@ impl SSHChaPoly {
             buf[..SSH_LENGTH_SIZE].try_into().unwrap();
         let mut c = Self::cha20(&self.k1, seq);
         c.apply_keystream(&mut b);
-        trace!("packet_length {:?}", b.hex_dump());
+        trace!("packet_length {:02x?}", b);
         Ok(u32::from_be_bytes(b))
     }
 

--- a/src/traffic.rs
+++ b/src/traffic.rs
@@ -9,8 +9,9 @@ use {
 use zeroize::Zeroize;
 
 use crate::channel::{ChanData, ChanNum};
-use crate::encrypt::KeyState;
-use crate::encrypt::{SSH_LENGTH_SIZE, SSH_PAYLOAD_START};
+use crate::encrypt::{
+    KeyState, KeysRecv, KeysSend, SSH_LENGTH_SIZE, SSH_PAYLOAD_START,
+};
 use crate::ident::RemoteVersion;
 use crate::packets::Packet;
 use crate::*;
@@ -358,7 +359,7 @@ impl<'a> TrafOut<'a> {
         match p.category() {
             packets::Category::All | packets::Category::Kex => (), // OK cleartext
             _ => {
-                if keys.is_cleartext() {
+                if keys.is_send_cleartext() {
                     return Error::bug_msg("send cleartext");
                 }
             }
@@ -478,12 +479,12 @@ impl<'s, 'a> TrafSend<'s, 'a> {
         self.out.send_packet(p.into(), self.keys)
     }
 
-    pub fn rekey(&mut self, keys: encrypt::Keys) {
-        self.keys.rekey(keys)
+    pub fn rekey_send(&mut self, keys: KeysSend, strict_kex: bool) {
+        self.keys.rekey_send(keys, strict_kex)
     }
 
-    pub fn enable_strict_kex(&mut self) {
-        self.keys.enable_strict_kex()
+    pub fn rekey_recv(&mut self, keys: KeysRecv) {
+        self.keys.rekey_recv(keys)
     }
 
     pub fn send_version(&mut self) -> Result<(), Error> {


### PR DESCRIPTION
Previously rekeying happened in both directions. That would be incorrect if packets are sent between sending NewKeys and receiving peer's NewKeys. Instead track them separately.
