### PR TITLE
Fix server pubkey verification

### DIFF
--- a/src/servauth.rs
+++ b/src/servauth.rs
@@ -130,7 +130,12 @@ impl ServAuth {
         // Extract the signature separately. The message for the signature
         // includes the auth packet without the signature part.
         let (key, sig) = match &mut p.method {
-            AuthMethod::PubKey(m) => (&m.pubkey.0, m.sig.take()),
+            AuthMethod::PubKey(m) => {
+                let sig = m.sig.take();
+                // When we have a signature, we need to set force_sig=true so that the encoded message for verification has the boolean set correctly
+                m.force_sig = sig.is_some();
+                (&m.pubkey.0, sig)
+            }
             _ => return Err(Error::bug()),
         };
 


### PR DESCRIPTION
This sets `force_sig` to `true` in the `ServAuth` flow so that the verified message matches what the client is sending.

Presently, the server `.take()`s the value out of the `Option`, thus causing a mismatch in the signed message bytes.