### PR TITLE
Configurable ServAuth

### DIFF
--- a/demo/common/src/server.rs
+++ b/demo/common/src/server.rs
@@ -171,7 +171,7 @@ impl DemoCommon {
         };
 
         // Explicitly enable password authentication
-        a.allow_password(true)?;
+        a.enable_password_auth(true)?;
         Ok(())
     }
 

--- a/demo/common/src/server.rs
+++ b/demo/common/src/server.rs
@@ -163,14 +163,15 @@ impl DemoCommon {
         a.reject()
     }
 
-    fn handle_firstauth(&self, a: ServFirstAuth) -> Result<()> {
+    fn handle_firstauth(&mut self, mut a: ServFirstAuth) -> Result<()> {
         let username = a.username()?;
         if !self.is_admin(username) && self.config.console_noauth {
             info!("Allowing auth for user {username}");
             return a.allow();
         };
 
-        // a.pubkey().password()
+        // Explicitly enable password authentication
+        a.allow_password(true)?;
         Ok(())
     }
 

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -717,6 +717,16 @@ impl Conn<Server> {
         let p = self.packet(payload)?;
         self.server()?.auth.resume_pkok(p, s)
     }
+
+    pub(crate) fn set_auth_methods(
+        &mut self,
+        password: bool,
+        pubkey: bool,
+    ) -> Result<()> {
+        let auth = &mut self.mut_server()?.auth;
+        auth.set_auth_methods(password, pubkey);
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/event.rs
+++ b/src/event.rs
@@ -400,19 +400,31 @@ impl<'g, 'a> ServPasswordAuth<'g, 'a> {
         self.runner.resume_servauth(false)
     }
 
-    /// Enable or disable password authentication for subsequent attempts
-    pub fn allow_password(&mut self, enabled: bool) -> Result<()> {
+    /// Enable or disable password authentication for subsequent attempts.
+    ///
+    /// # Caution
+    /// Enabling or disabling authentication methods based on username can
+    /// unintentionally enable user enumeration attacks.
+    pub fn enable_password_auth(&mut self, enabled: bool) -> Result<()> {
         let (_, pubkey) = self.runner.get_auth_methods()?;
         self.runner.set_auth_methods(enabled, pubkey)
     }
 
-    /// Enable or disable public key authentication for subsequent attempts
-    pub fn allow_pubkey(&mut self, enabled: bool) -> Result<()> {
+    /// Enable or disable public key authentication for subsequent attempts.
+    ///
+    /// # Caution
+    /// Enabling or disabling authentication methods based on username can
+    /// unintentionally enable user enumeration attacks.
+    pub fn enable_pubkey_auth(&mut self, enabled: bool) -> Result<()> {
         let (password, _) = self.runner.get_auth_methods()?;
         self.runner.set_auth_methods(password, enabled)
     }
 
-    /// Configure which authentication methods are allowed for subsequent attempts
+    /// Configure which authentication methods are allowed for subsequent attempts.
+    ///
+    /// # Caution
+    /// Enabling or disabling authentication methods based on username can
+    /// unintentionally enable user enumeration attacks.
     pub fn set_auth_methods(&mut self, password: bool, pubkey: bool) -> Result<()> {
         self.runner.set_auth_methods(password, pubkey)
     }
@@ -485,19 +497,31 @@ impl<'g, 'a> ServPubkeyAuth<'g, 'a> {
         self.runner.resume_servauth(false)
     }
 
-    /// Enable or disable password authentication for subsequent attempts
-    pub fn allow_password(&mut self, enabled: bool) -> Result<()> {
+    /// Enable or disable password authentication for subsequent attempts.
+    ///
+    /// # Caution
+    /// Enabling or disabling authentication methods based on username can
+    /// unintentionally enable user enumeration attacks.
+    pub fn enable_password_auth(&mut self, enabled: bool) -> Result<()> {
         let (_, pubkey) = self.runner.get_auth_methods()?;
         self.runner.set_auth_methods(enabled, pubkey)
     }
 
-    /// Enable or disable public key authentication for subsequent attempts
-    pub fn allow_pubkey(&mut self, enabled: bool) -> Result<()> {
+    /// Enable or disable public key authentication for subsequent attempts.
+    ///
+    /// # Caution
+    /// Enabling or disabling authentication methods based on username can
+    /// unintentionally enable user enumeration attacks.
+    pub fn enable_pubkey_auth(&mut self, enabled: bool) -> Result<()> {
         let (password, _) = self.runner.get_auth_methods()?;
         self.runner.set_auth_methods(password, enabled)
     }
 
-    /// Configure which authentication methods are allowed for subsequent attempts
+    /// Configure which authentication methods are allowed for subsequent attempts.
+    ///
+    /// # Caution
+    /// Enabling or disabling authentication methods based on username can
+    /// unintentionally enable user enumeration attacks.
     pub fn set_auth_methods(&mut self, password: bool, pubkey: bool) -> Result<()> {
         self.runner.set_auth_methods(password, pubkey)
     }
@@ -559,19 +583,31 @@ impl<'g, 'a> ServFirstAuth<'g, 'a> {
         self.runner.resume_servauth(false)
     }
 
-    /// Enable or disable password authentication for this session
-    pub fn allow_password(&mut self, enabled: bool) -> Result<()> {
+    /// Enable or disable password authentication for this session.
+    ///
+    /// # Caution
+    /// Enabling or disabling authentication methods based on username can
+    /// unintentionally enable user enumeration attacks.
+    pub fn enable_password_auth(&mut self, enabled: bool) -> Result<()> {
         let (_, pubkey) = self.runner.get_auth_methods()?;
         self.runner.set_auth_methods(enabled, pubkey)
     }
 
-    /// Enable or disable public key authentication for this session
-    pub fn allow_pubkey(&mut self, enabled: bool) -> Result<()> {
+    /// Enable or disable public key authentication for this session.
+    ///
+    /// # Caution
+    /// Enabling or disabling authentication methods based on username can
+    /// unintentionally enable user enumeration attacks.
+    pub fn enable_pubkey_auth(&mut self, enabled: bool) -> Result<()> {
         let (password, _) = self.runner.get_auth_methods()?;
         self.runner.set_auth_methods(password, enabled)
     }
 
-    /// Configure which authentication methods are allowed
+    /// Configure which authentication methods are allowed.
+    ///
+    /// # Caution
+    /// Enabling or disabling authentication methods based on username can
+    /// unintentionally enable user enumeration attacks.
     pub fn set_auth_methods(&mut self, password: bool, pubkey: bool) -> Result<()> {
         self.runner.set_auth_methods(password, pubkey)
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -381,6 +381,9 @@ impl<'g, 'a> ServPasswordAuth<'g, 'a> {
     }
 
     /// Perform a constant-time comparison of the user-presented password against a passed string.
+    /// # Caution
+    /// This is better than a naive comparison, but passwords should be hashed and stored using a
+    /// platform-appropriate password hashing function. Consider bcrypt, argon2, or pbkdf2.
     pub fn matches_password(
         &self,
         password: impl core::convert::AsRef<str>,

--- a/src/event.rs
+++ b/src/event.rs
@@ -387,8 +387,11 @@ impl<'g, 'a> ServPasswordAuth<'g, 'a> {
     pub fn matches_password(
         &self,
         password: impl core::convert::AsRef<str>,
-    ) -> Result<bool> {
-        Ok(self.password()?.as_bytes().ct_eq(password.as_ref().as_bytes()).into())
+    ) -> bool {
+        match self.password() {
+            Ok(p) => p.as_bytes().ct_eq(password.as_ref().as_bytes()).into(),
+            _ => false,
+        }
     }
 
     /// Accept the presented password.

--- a/src/event.rs
+++ b/src/event.rs
@@ -367,8 +367,11 @@ impl<'g, 'a> ServPasswordAuth<'g, 'a> {
     pub fn matches_username(
         &self,
         username: impl core::convert::AsRef<str>,
-    ) -> Result<bool> {
-        Ok(self.username()?.as_bytes().ct_eq(username.as_ref().as_bytes()).into())
+    ) -> bool {
+        match self.username() {
+            Ok(u) => u.as_bytes().ct_eq(username.as_ref().as_bytes()).into(),
+            _ => false,
+        }
     }
 
     /// Retrieve the password presented by the user.
@@ -567,8 +570,11 @@ impl<'g, 'a> ServFirstAuth<'g, 'a> {
     pub fn matches_username(
         &self,
         username: impl core::convert::AsRef<str>,
-    ) -> Result<bool> {
-        Ok(self.username()?.as_bytes().ct_eq(username.as_ref().as_bytes()).into())
+    ) -> bool {
+        match self.username() {
+            Ok(u) => u.as_bytes().ct_eq(username.as_ref().as_bytes()).into(),
+            _ => false,
+        }
     }
 
     /// Allow the user to log in.

--- a/src/event.rs
+++ b/src/event.rs
@@ -383,6 +383,23 @@ impl<'g, 'a> ServPasswordAuth<'g, 'a> {
         self.runner.resume_servauth(false)
     }
 
+    /// Enable or disable password authentication for subsequent attempts
+    pub fn allow_password(&mut self, enabled: bool) -> Result<()> {
+        let (_, pubkey) = self.runner.get_auth_methods()?;
+        self.runner.set_auth_methods(enabled, pubkey)
+    }
+
+    /// Enable or disable public key authentication for subsequent attempts
+    pub fn allow_pubkey(&mut self, enabled: bool) -> Result<()> {
+        let (password, _) = self.runner.get_auth_methods()?;
+        self.runner.set_auth_methods(password, enabled)
+    }
+
+    /// Configure which authentication methods are allowed for subsequent attempts
+    pub fn set_auth_methods(&mut self, password: bool, pubkey: bool) -> Result<()> {
+        self.runner.set_auth_methods(password, pubkey)
+    }
+
     pub fn raw_username(&self) -> Result<TextString<'_>> {
         self.runner.fetch_servusername()
     }
@@ -451,6 +468,23 @@ impl<'g, 'a> ServPubkeyAuth<'g, 'a> {
         self.runner.resume_servauth(false)
     }
 
+    /// Enable or disable password authentication for subsequent attempts
+    pub fn allow_password(&mut self, enabled: bool) -> Result<()> {
+        let (_, pubkey) = self.runner.get_auth_methods()?;
+        self.runner.set_auth_methods(enabled, pubkey)
+    }
+
+    /// Enable or disable public key authentication for subsequent attempts
+    pub fn allow_pubkey(&mut self, enabled: bool) -> Result<()> {
+        let (password, _) = self.runner.get_auth_methods()?;
+        self.runner.set_auth_methods(password, enabled)
+    }
+
+    /// Configure which authentication methods are allowed for subsequent attempts
+    pub fn set_auth_methods(&mut self, password: bool, pubkey: bool) -> Result<()> {
+        self.runner.set_auth_methods(password, pubkey)
+    }
+
     pub fn raw_username(&self) -> Result<TextString<'_>> {
         self.runner.fetch_servusername()
     }
@@ -498,6 +532,23 @@ impl<'g, 'a> ServFirstAuth<'g, 'a> {
     pub fn reject(mut self) -> Result<()> {
         self.done = true;
         self.runner.resume_servauth(false)
+    }
+
+    /// Enable or disable password authentication for this session
+    pub fn allow_password(&mut self, enabled: bool) -> Result<()> {
+        let (_, pubkey) = self.runner.get_auth_methods()?;
+        self.runner.set_auth_methods(enabled, pubkey)
+    }
+
+    /// Enable or disable public key authentication for this session
+    pub fn allow_pubkey(&mut self, enabled: bool) -> Result<()> {
+        let (password, _) = self.runner.get_auth_methods()?;
+        self.runner.set_auth_methods(password, enabled)
+    }
+
+    /// Configure which authentication methods are allowed
+    pub fn set_auth_methods(&mut self, password: bool, pubkey: bool) -> Result<()> {
+        self.runner.set_auth_methods(password, pubkey)
     }
 
     pub fn raw_username(&self) -> Result<TextString<'_>> {

--- a/src/event.rs
+++ b/src/event.rs
@@ -10,6 +10,7 @@ use self::{
 use {
     crate::error::{Error, Result, TrapBug},
     log::{debug, error, info, log, trace, warn},
+    subtle::ConstantTimeEq,
 };
 
 use core::fmt::Debug;
@@ -362,6 +363,14 @@ impl<'g, 'a> ServPasswordAuth<'g, 'a> {
         self.raw_username()?.as_str()
     }
 
+    /// Perform a constant-time comparison of the user-presented username against a passed string.
+    pub fn matches_username(
+        &self,
+        username: impl core::convert::AsRef<str>,
+    ) -> Result<bool> {
+        Ok(self.username()?.as_bytes().ct_eq(username.as_ref().as_bytes()).into())
+    }
+
     /// Retrieve the password presented by the user.
     ///
     /// When comparing with an expected password or hash, take
@@ -369,6 +378,14 @@ impl<'g, 'a> ServPasswordAuth<'g, 'a> {
     /// by using [`subtle`](https://docs.rs/subtle/latest/subtle/) crate.
     pub fn password(&self) -> Result<&str> {
         self.raw_password()?.as_str()
+    }
+
+    /// Perform a constant-time comparison of the user-presented password against a passed string.
+    pub fn matches_password(
+        &self,
+        password: impl core::convert::AsRef<str>,
+    ) -> Result<bool> {
+        Ok(self.password()?.as_bytes().ct_eq(password.as_ref().as_bytes()).into())
     }
 
     /// Accept the presented password.
@@ -514,6 +531,14 @@ impl<'g, 'a> ServFirstAuth<'g, 'a> {
     /// Retrieve the username presented by the client.
     pub fn username(&self) -> Result<&str> {
         self.raw_username()?.as_str()
+    }
+
+    /// Perform a constant-time comparison of the user-presented username against a passed string.
+    pub fn matches_username(
+        &self,
+        username: impl core::convert::AsRef<str>,
+    ) -> Result<bool> {
+        Ok(self.username()?.as_bytes().ct_eq(username.as_ref().as_bytes()).into())
     }
 
     /// Allow the user to log in.

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -372,11 +372,6 @@ impl PubKey<'_> {
 
         Ok(ssh_key.fingerprint(hash_alg))
     }
-
-    #[cfg(feature = "openssh-key")]
-    pub fn matches_fingerprint(&self, fp: &ssh_key::Fingerprint) -> Result<bool> {
-        Ok(self.fingerprint(fp.algorithm())?.as_bytes().ct_eq(fp.as_bytes()).into())
-    }
 }
 
 // ssh_key::PublicKey is used for known_hosts comparisons

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -263,7 +263,11 @@ impl<'a> Runner<'a, server::Server> {
         r
     }
 
-    pub(crate) fn set_auth_methods(&mut self, password: bool, pubkey: bool) -> Result<()> {
+    pub(crate) fn set_auth_methods(
+        &mut self,
+        password: bool,
+        pubkey: bool,
+    ) -> Result<()> {
         self.conn.set_auth_methods(password, pubkey)
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -262,6 +262,15 @@ impl<'a> Runner<'a, server::Server> {
         self.traf_in.done_payload();
         r
     }
+
+    pub(crate) fn set_auth_methods(&mut self, password: bool, pubkey: bool) -> Result<()> {
+        self.conn.set_auth_methods(password, pubkey)
+    }
+
+    pub(crate) fn get_auth_methods(&self) -> Result<(bool, bool)> {
+        let auth = &self.conn.server()?.auth;
+        Ok((auth.method_password, auth.method_pubkey))
+    }
 }
 
 impl<'a, CS: CliServ> Runner<'a, CS> {

--- a/src/servauth.rs
+++ b/src/servauth.rs
@@ -29,7 +29,6 @@ pub(crate) struct ServAuth {
     /// Username previously used, as an array of bytes
     pub username: Option<Vec<u8, { config::MAX_USERNAME }>>,
 
-    // TODO Add setters for methods in Runner/SSHServer creation.
     /// Whether to advertise password authentication and present it to the application
     ///
     /// Enabled by default
@@ -53,6 +52,12 @@ impl Default for ServAuth {
 }
 
 impl ServAuth {
+    /// Configure which authentication methods are allowed
+    pub fn set_auth_methods(&mut self, password: bool, pubkey: bool) {
+        self.method_password = password;
+        self.method_pubkey = pubkey;
+    }
+
     /// Returns an event for the app, or `DispatchEvent::None` if auth failure
     /// has been returned immediately.
     pub fn request(


### PR DESCRIPTION
This PR adds some helpful tools for implementing server authentication and key management flows. These are mainly QoL improvements, some of them could be optional (this is more of an RFC.)

**In my opinion: no authentication strategies should be permitted by default in security-focused software - I didn't change the handle_password/handle_pubkey values to default to `false` as that would be a breaking change (but IMO this would be a good idea.)**

I believe these helpers will remove some of the potential footguns for folks with regards to validating passwords/pubkeys (namely, time-sensitive comparison.) Importantly: users won't have to include (or know that they need to include) `subtle` or similar libraries for safe comparisons