### PR TITLE
Environment variable passing support

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -900,6 +900,9 @@ impl Channel {
             ChannelReqType::Pty(_) => {
                 Ok(DispatchEvent::ServEvent(ServEventId::SessionPty { num }))
             }
+            ChannelReqType::Environment(_) => {
+                Ok(DispatchEvent::ServEvent(ServEventId::Environment { num }))
+            }
             _ => {
                 if let ChannelReqType::Unknown(u) = &p.req {
                     warn!("Unknown channel req type \"{}\"", u)

--- a/src/event.rs
+++ b/src/event.rs
@@ -300,6 +300,8 @@ pub enum ServEvent<'g, 'a> {
     ///
     /// TODO details
     SessionPty(ServPtyRequest<'g, 'a>),
+    /// Server has received one environment variable
+    Environment(ServEnvironmentRequest<'g, 'a>),
 
     /// The SSH session is no longer running
     #[allow(unused)]
@@ -325,6 +327,7 @@ impl Debug for ServEvent<'_, '_> {
             Self::SessionExec(_) => "SessionExec",
             Self::SessionSubsystem(_) => "SessionSubsystem",
             Self::SessionPty(_) => "SessionPty",
+            Self::Environment(_) => "Environment",
             Self::Defunct => "Defunct",
             Self::PollAgain => "PollAgain",
         };
@@ -723,6 +726,49 @@ impl Drop for ServPtyRequest<'_, '_> {
     }
 }
 
+/// An environment variable request
+///
+pub struct ServEnvironmentRequest<'g, 'a> {
+    runner: &'g mut Runner<'a, Server>,
+    num: ChanNum,
+    done: bool,
+}
+
+impl<'g, 'a> ServEnvironmentRequest<'g, 'a> {
+    fn new(runner: &'g mut Runner<'a, Server>, num: ChanNum) -> Self {
+        Self { runner, num, done: false }
+    }
+
+    /// Indicate that the request succeeded.
+    ///
+    /// Note that if the peer didn't request a reply, this call
+    /// will not do anything.
+    pub fn succeed(mut self) -> Result<()> {
+        self.done = true;
+        self.runner.resume_chanreq(true)
+    }
+
+    /// Indicate that the request failed.
+    ///
+    /// Note that if the peer didn't request a reply, this call
+    /// will not do anything.
+    /// Does not need to be called explicitly, also occurs on drop without `accept()`
+    pub fn fail(mut self) -> Result<()> {
+        self.done = true;
+        self.runner.resume_chanreq(false)
+    }
+
+    /// Return the associated channel number.
+    ///
+    /// This will correspond to a `ChanHandle::num()`
+    /// from a previous [`ServOpenSession`] event.
+    pub fn channel(&self) -> ChanNum {
+        self.num
+    }
+
+    // TODO: does the app care about wantreply?
+}
+
 // Only small values should be stored inline.
 // Larger state is retrieved from the current packet via Runner::fetch_*()
 #[derive(Debug, Clone)]
@@ -746,6 +792,9 @@ pub(crate) enum ServEventId {
         num: ChanNum,
     },
     SessionPty {
+        num: ChanNum,
+    },
+    Environment {
         num: ChanNum,
     },
     #[allow(unused)]
@@ -801,6 +850,10 @@ impl ServEventId {
                 debug_assert!(matches!(p, Some(Packet::ChannelRequest(_))));
                 Ok(ServEvent::SessionPty(ServPtyRequest::new(runner, num)))
             }
+            Self::Environment { num } => {
+                debug_assert!(matches!(p, Some(Packet::ChannelRequest(_))));
+                Ok(ServEvent::Environment(ServEnvironmentRequest::new(runner, num)))
+            }
             Self::Defunct => Ok(ServEvent::Defunct),
         }
     }
@@ -818,6 +871,7 @@ impl ServEventId {
             | Self::SessionShell { .. }
             | Self::SessionExec { .. }
             | Self::SessionSubsystem { .. }
+            | Self::Environment { .. }
             | Self::SessionPty { .. } => true,
         }
     }

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -2,7 +2,7 @@
 //!
 //! A [`Packet`] can be encoded/decoded to the
 //! SSH Binary Packet Protocol using [`sshwire`].
-//! SSH packet format is described in [RFC4253](https://tools.ietf.org/html/rfc5643) SSH Transport
+//! SSH packet format is described in [RFC4253](https://tools.ietf.org/html/rfc4253#section-6) SSH Transport
 
 #[allow(unused_imports)]
 use {
@@ -711,6 +711,8 @@ pub enum ChannelReqType<'a> {
     Subsystem(Subsystem<'a>),
     #[sshwire(variant = "window-change")]
     WinChange(WinChange),
+    #[sshwire(variant = "env")]
+    Environment(Environment<'a>),
     #[sshwire(variant = "signal")]
     Signal(Signal<'a>),
     #[sshwire(variant = "exit-status")]
@@ -764,6 +766,15 @@ pub struct WinChange {
     pub rows: u32,
     pub width: u32,
     pub height: u32,
+}
+
+/// An environment variable
+#[derive(Debug, SSHEncode, SSHDecode)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct Environment<'a> {
+    pub key: &'a str,
+    pub value: &'a str,
+    // pub env: &'a str, // "key=value"
 }
 
 /// A unix signal channel request


### PR DESCRIPTION
Adds the necessary structs/types/event for env var sending/handling (and avoids runtime message: WARN - Unknown channel req type 'env')... that's according to RFC 4254, but we'll deem more env vars as 'safe to pass' than just LANG, TERM, and DISPLAY.