### PR TITLE
Add alloc feature with owned buffers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
   all:
     strategy:
       matrix:
-        # 1.88 is an arbitrary minimum, tested to notice when it bumps
-        rust_version: [stable, 1.88]
+        # 1.89 is an arbitrary minimum, tested to notice when it bumps
+        rust_version: [stable, 1.89]
     runs-on: ubuntu-latest
     env:
       RUSTUP_TOOLCHAIN: ${{ matrix.rust_version }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3143,7 +3143,6 @@ dependencies = [
  "time",
  "tokio",
  "whoami",
- "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,8 @@ ecdsa = { version = "0.17.0-rc.17", default-features = false, optional = true , 
 
 [features]
 default = []
-std = ["snafu/std", "ssh-key/alloc", "larger", "mlkem"]
+std = ["snafu/std", "ssh-key/alloc", "larger", "mlkem", "alloc"]
+alloc = ["ssh-key/alloc"]
 backtrace = ["snafu/backtrace"]
 rsa = ["dep:rsa", "ssh-key/rsa"]
 mlkem = ["dep:ml-kem"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/mkj/sunset"
 categories = ["network-programming", "embedded", "no-std"]
 license = "0BSD"
 keywords = ["ssh"]
-rust-version = "1.88"
+rust-version = "1.89"
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Desirable:
 
 ## Rust versions
 
-At the time of writing Sunset will build with Rust 1.88.
+At the time of writing Sunset will build with Rust 1.89.
 The requirement may increase whenever useful, targetting stable.
 
 ## Checks

--- a/async/Cargo.toml
+++ b/async/Cargo.toml
@@ -23,3 +23,5 @@ log = { version = "0.4" }
 # The application should depend on critical-section "std" feature.
 # When multi-thread is disabled locking overhead is avoided.
 multi-thread = []
+alloc = ["sunset/alloc"]
+std = ["sunset/std", "alloc"]

--- a/async/src/async_channel.rs
+++ b/async/src/async_channel.rs
@@ -122,6 +122,11 @@ impl<'g> ChanIn<'g> {
         Self(io)
     }
 
+    /// Return the channel number.
+    pub fn num(&self) -> ChanNum {
+        self.0.num
+    }
+
     /// Wait until the channel closes.
     pub async fn until_closed(&self) -> Result<()> {
         self.0.until_closed().await
@@ -157,6 +162,11 @@ pub struct ChanOut<'g>(ChanIO<'g>);
 impl<'g> ChanOut<'g> {
     pub(crate) fn new(io: ChanIO<'g>) -> Self {
         Self(io)
+    }
+
+    /// Return the channel number.
+    pub fn num(&self) -> ChanNum {
+        self.0.num
     }
 
     /// Wait until the channel closes.
@@ -200,6 +210,11 @@ impl<'g> ChanInOut<'g> {
     pub(crate) fn new(io: ChanIO<'g>) -> Self {
         io.sunset.inc_read_chan(io.num, io.dt);
         Self(io)
+    }
+
+    /// Return the channel number.
+    pub fn num(&self) -> ChanNum {
+        self.0.num
     }
 
     /// Convert this into separate input and output.

--- a/async/src/client.rs
+++ b/async/src/client.rs
@@ -71,3 +71,12 @@ impl<'a> SSHClient<'a> {
         Ok(ChanInOut::new(self.sunset.add_channel(ch).await?))
     }
 }
+
+#[cfg(feature = "alloc")]
+impl SSHClient<'static> {
+    pub fn new_owned() -> Self {
+        let runner = Runner::<'static, _>::new_client_owned();
+        let sunset = AsyncSunset::new(runner);
+        Self { sunset }
+    }
+}

--- a/async/src/lib.rs
+++ b/async/src/lib.rs
@@ -1,7 +1,7 @@
 //! Async for Sunset SSH
 //!
 //! This provides async for Sunset SSH.
-#![no_std]
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![forbid(unsafe_code)]
 // avoid mysterious missing awaits
 #![deny(unused_must_use)]

--- a/async/src/server.rs
+++ b/async/src/server.rs
@@ -77,3 +77,11 @@ impl<'a> SSHServer<'a> {
         Ok((i, e))
     }
 }
+#[cfg(feature = "alloc")]
+impl SSHServer<'static> {
+    pub fn new_owned() -> Self {
+        let runner = Runner::new_server_owned();
+        let sunset = AsyncSunset::new(runner);
+        Self { sunset }
+    }
+}

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1145,10 +1145,7 @@ pub struct CliSessionOpener<'g, 'a> {
 }
 
 impl<'g, 'a> CliSessionOpener<'g, 'a> {
-    /// Returns the channel associated with this session.
-    ///
-    /// This will match that previously returned from [`Runner::open_client_session`]
-    /// or `SSHClient::open_session_pty()` (or `_nopty()`)
+    /// Returns the channel number associated with this session.
     pub fn channel(&self) -> ChanNum {
         self.ch.num()
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,12 @@
 pub const DEFAULT_WINDOW: usize = 1000;
 pub const DEFAULT_MAX_PACKET: usize = 1000;
 
+/// Maximum SSH packet size, from RFC4253.
+///
+/// Used to size buffers when using `alloc`
+#[allow(unused)]
+pub(crate) const SSH_MAX_PACKET: usize = 35000;
+
 // TODO: Perhaps instead of MAX_CHANNELS we could have a type alias
 // of either heapless::Vec<> or std::vec::Vec<>
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ use conn::DispatchEvent;
 pub use sshwire::TextString;
 
 pub use auth::AuthSigMsg;
-pub use channel::{ChanData, ChanNum, CliSessionExit};
+pub use channel::{ChanData, ChanNum, CliSessionExit, CliSessionOpener};
 pub use channel::{ChanOpened, Pty, SessionCommand};
 pub use error::{Error, Result};
 pub use packets::{PubKey, Signature};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,9 @@
 // Static allocations hit this inherently.
 #![allow(clippy::large_enum_variant)]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 pub mod config;
 pub mod packets;
 pub mod sshnames;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -172,6 +172,16 @@ impl<'a> Runner<'a, client::Client> {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl Runner<'static, client::Client> {
+    /// Create a client Runner with owned packet buffers.
+    ///
+    /// Only available running with `alloc` or `std` feature.
+    pub fn new_client_owned() -> Self {
+        Self::new_owned()
+    }
+}
+
 impl<'a> Runner<'a, server::Server> {
     /// `inbuf` and `outbuf` must be sized to fit the largest SSH packet allowed.
     pub fn new_server(
@@ -252,12 +262,26 @@ impl<'a> Runner<'a, server::Server> {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl Runner<'static, server::Server> {
+    /// Create a server Runner with owned packet buffers.
+    ///
+    /// Only available running with `alloc` or `std` feature.
+    pub fn new_server_owned() -> Self {
+        Self::new_owned()
+    }
+}
+
 impl<'a, CS: CliServ> Runner<'a, CS> {
     pub fn new(inbuf: &'a mut [u8], outbuf: &'a mut [u8]) -> Runner<'a, CS> {
+        Self::new_traf(TrafIn::new(inbuf), TrafOut::new(outbuf))
+    }
+
+    fn new_traf(traf_in: TrafIn<'a>, traf_out: TrafOut<'a>) -> Runner<'a, CS> {
         Runner {
             conn: Conn::new(),
-            traf_in: TrafIn::new(inbuf),
-            traf_out: TrafOut::new(outbuf),
+            traf_in,
+            traf_out,
             keys: KeyState::new_cleartext(),
             output_waker: None,
             input_waker: None,
@@ -791,6 +815,13 @@ impl<'a, CS: CliServ> Runner<'a, CS> {
         let (payload, _seq) = self.traf_in.payload().trap()?;
         let p = self.conn.packet(payload)?;
         self.conn.channels.fetch_env_value(&p)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<CS: CliServ> Runner<'static, CS> {
+    pub fn new_owned() -> Runner<'static, CS> {
+        Self::new_traf(TrafIn::new_owned(), TrafOut::new_owned())
     }
 }
 

--- a/src/traffic.rs
+++ b/src/traffic.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use core::ops::{Deref, DerefMut};
 
 #[allow(unused_imports)]
 use {
@@ -6,12 +7,54 @@ use {
     log::{debug, error, info, log, trace, warn},
 };
 
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
 
 use crate::channel::{ChanData, ChanNum};
 use crate::encrypt::{KeyState, KeysRecv, KeysSend, SSH_PAYLOAD_START};
 use crate::ident::RemoteVersion;
 use crate::*;
+
+// Either a slice or boxed array.
+// Similar to managed::ManagedSlice.
+#[derive(ZeroizeOnDrop)]
+enum SliceOrVec<'a> {
+    Borrowed(&'a mut [u8]),
+
+    /// `'static` variant
+    #[cfg(feature = "alloc")]
+    Owned(Box<[u8; config::SSH_MAX_PACKET]>),
+}
+
+impl Deref for SliceOrVec<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Borrowed(r) => r,
+            #[cfg(feature = "alloc")]
+            Self::Owned(r) => r.as_ref(),
+        }
+    }
+}
+
+impl DerefMut for SliceOrVec<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Self::Borrowed(r) => r,
+            #[cfg(feature = "alloc")]
+            Self::Owned(r) => r.as_mut(),
+        }
+    }
+}
+
+impl Zeroize for SliceOrVec<'_> {
+    fn zeroize(&mut self) {
+        self.deref_mut().zeroize();
+    }
+}
 
 // TODO: if smoltcp exposed both ends of a CircularBuffer to recv()
 // we could perhaps just work directly in smoltcp's provided buffer?
@@ -26,7 +69,7 @@ pub struct TrafIn<'a> {
     /// Should be sized to fit the largest packet allowed for input.
     /// Contains ciphertext or cleartext, decrypted in-place.
     /// Only contains a single SSH packet at a time.
-    buf: &'a mut [u8],
+    buf: SliceOrVec<'a>,
     state: RxState,
 }
 
@@ -63,7 +106,7 @@ impl core::fmt::Debug for TrafIn<'_> {
 
 impl<'a> TrafIn<'a> {
     pub fn new(buf: &'a mut [u8]) -> Self {
-        Self { buf, state: RxState::Idle }
+        Self { buf: SliceOrVec::Borrowed(buf), state: RxState::Idle }
     }
 
     pub fn is_input_ready(&self) -> bool {
@@ -308,7 +351,7 @@ pub(crate) struct TrafOut<'a> {
     /// Contains ciphertext or cleartext, encrypted in-place.
     /// Writing may contain multiple SSH packets to write out, encrypted
     /// in-place as they are written to `buf`.
-    buf: &'a mut [u8],
+    buf: SliceOrVec<'a>,
     state: TxState,
 }
 
@@ -338,9 +381,18 @@ impl core::fmt::Debug for TrafOut<'_> {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl TrafIn<'static> {
+    pub fn new_owned() -> Self {
+        let mut s = Self::new(&mut []);
+        s.buf = SliceOrVec::Owned(Box::new([0; _]));
+        s
+    }
+}
+
 impl<'a> TrafOut<'a> {
     pub fn new(buf: &'a mut [u8]) -> Self {
-        Self { buf, state: TxState::Idle }
+        Self { buf: SliceOrVec::Borrowed(buf), state: TxState::Idle }
     }
 
     /// Serializes and and encrypts a packet to send
@@ -423,7 +475,7 @@ impl<'a> TrafOut<'a> {
             return Err(Error::bug());
         }
 
-        let len = ident::write_version(self.buf)?;
+        let len = ident::write_version(&mut self.buf)?;
         self.state = TxState::Write { idx: 0, len };
         Ok(())
     }
@@ -452,6 +504,15 @@ impl<'a> TrafOut<'a> {
 
     pub fn sender<'s>(&'s mut self, keys: &'s mut KeyState) -> TrafSend<'s, 'a> {
         TrafSend::new(self, keys)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl TrafOut<'static> {
+    pub fn new_owned() -> Self {
+        let mut s = Self::new(&mut []);
+        s.buf = SliceOrVec::Owned(Box::new([0; _]));
+        s
     }
 }
 

--- a/stdasync/Cargo.toml
+++ b/stdasync/Cargo.toml
@@ -37,7 +37,6 @@ rsa = ["sunset/rsa"]
 [dev-dependencies]
 anyhow = { version = "1.0" }
 whoami = "1.3"
-zeroize = "1.5"
 
 tokio = { version = "1.25", features = ["full"] }
 

--- a/stdasync/Cargo.toml
+++ b/stdasync/Cargo.toml
@@ -48,5 +48,5 @@ simplelog = "0.12"
 # for simplelog
 time = { version = "0.3", features = ["local-offset"] }
 
-sunset-async = { workspace = true, features = ["multi-thread"] }
+sunset-async = { workspace = true, features = ["multi-thread", "std"] }
 critical-section = { version = "1.1", features = ["std"] }

--- a/stdasync/examples/sunsetc.rs
+++ b/stdasync/examples/sunsetc.rs
@@ -19,8 +19,6 @@ use sunset_stdasync::{AgentClient, CmdlineClient};
 
 use embedded_io_adapters::tokio_1::FromTokio;
 
-use zeroize::Zeroizing;
-
 use simplelog::*;
 use time::UtcOffset;
 
@@ -83,10 +81,6 @@ async fn run(args: Args) -> Result<ExitCode> {
     // sunsetc example here uses the normal threaded scheduler in order to test the
     // "multi-thread" feature (and as a more "default" example).
     let ssh_task = tokio::task::spawn(async move {
-        let mut rxbuf = Zeroizing::new(vec![0; 3000]);
-        let mut txbuf = Zeroizing::new(vec![0; 3000]);
-        let ssh = SSHClient::new(&mut rxbuf, &mut txbuf);
-
         // CmdlineClient implements the session logic for a commandline SSH client.
         let mut app =
             CmdlineClient::new(args.username.as_ref().unwrap(), &args.host);
@@ -120,6 +114,7 @@ async fn run(args: Args) -> Result<ExitCode> {
         let mut wsock = FromTokio::new(wsock);
 
         // SSH connection future
+        let ssh = SSHClient::new_owned();
         let ssh_fut = ssh.run(&mut rsock, &mut wsock);
 
         // Client session future

--- a/stdasync/src/cmdline_client.rs
+++ b/stdasync/src/cmdline_client.rs
@@ -232,10 +232,7 @@ impl CmdlineClient {
     ///
     /// Performs authentication, requests a shell or command, performs channel IO.
     /// Will return `Ok` after the session ends normally, or an error.
-    pub async fn run<'g: 'a, 'a>(
-        &mut self,
-        cli: &'g SSHClient<'a>,
-    ) -> Result<ExitCode> {
+    pub async fn run<'g, 'a>(&mut self, cli: &'g SSHClient<'a>) -> Result<ExitCode> {
         let mut io = None;
         let mut extin = None;
 
@@ -349,7 +346,7 @@ impl CmdlineClient {
     /// Requests a PTY or non-PTY session
     ///
     /// Sets up the PTY if required.
-    async fn open_session<'g: 'a, 'a>(
+    async fn open_session<'g, 'a>(
         &mut self,
         cli: &'g SSHClient<'a>,
     ) -> Result<(ChanInOut<'g>, Option<ChanIn<'g>>)> {


### PR DESCRIPTION
On alloc platforms it's simpler if sunset owns its own buffers.

Also fixes a couple of other problems such as `CliSessionOpener` not being visible.