### PR TITLE
async: Call set_channel_write_waker()

### DIFF
--- a/async/src/async_sunset.rs
+++ b/async/src/async_sunset.rs
@@ -602,7 +602,7 @@ impl<'a, CS: CliServ> ChanCore for AsyncSunset<'a, CS> {
         if let Ok(0) = l {
             // 0 bytes written, pending
             trace!("write ch {num:?} dt {dt:?} pending");
-            runner.set_channel_read_waker(h, dt, cx.waker());
+            runner.set_channel_write_waker(h, dt, cx.waker());
             Poll::Pending
         } else {
             trace!("write ready ch {num:?} dt {dt:?} {l:?}");


### PR DESCRIPTION
This was a copy and paste bug calling set_channel_read_waker() instead. It could cause connections to get stuck, observed with rsync getting stuck at the first SSH packet buffer size (either ~700 bytes or 32768 bytes).

Kind of a follow up to #51, but was found coincidentally.