### PR TITLE
Fix for SFTP test performance and stall

### DIFF
--- a/async/src/async_sunset.rs
+++ b/async/src/async_sunset.rs
@@ -382,7 +382,10 @@ impl<'a, CS: CliServ> AsyncSunset<'a, CS> {
                 };
 
                 let r = match res {
-                    Pending => Pending,
+                    Pending => {
+                        // wsock has set a waker
+                        Pending
+                    }
                     Ready(Ok(0)) => {
                         info!("socket EOF");
                         inner.runner.close_output();
@@ -397,6 +400,7 @@ impl<'a, CS: CliServ> AsyncSunset<'a, CS> {
                             // registers a waker.
                             continue;
                         }
+                        inner.runner.set_output_waker(cx.waker());
                         if !inner.runner.is_output_pending() {
                             // All output was sent. Wake progress
                             // in case window adjustments etc need to be sent
@@ -411,9 +415,6 @@ impl<'a, CS: CliServ> AsyncSunset<'a, CS> {
                         Ready(error::ChannelEOF.fail())
                     }
                 };
-                if r.is_pending() {
-                    inner.runner.set_output_waker(cx.waker());
-                }
                 return r;
             }
         })

--- a/async/src/async_sunset.rs
+++ b/async/src/async_sunset.rs
@@ -397,6 +397,12 @@ impl<'a, CS: CliServ> AsyncSunset<'a, CS> {
                             // registers a waker.
                             continue;
                         }
+                        if !inner.runner.is_output_pending() {
+                            // All output was sent. Wake progress
+                            // in case window adjustments etc need to be sent
+                            // now that there is available space.
+                            self.wake_progress();
+                        }
                         Pending
                     }
                     Ready(Err(_e)) => {

--- a/demo/common/src/server.rs
+++ b/demo/common/src/server.rs
@@ -34,7 +34,7 @@ pub async fn listen(
     let mut tx_tcp = [0; 1550];
 
     let mut socket = TcpSocket::new(stack, &mut rx_tcp, &mut tx_tcp);
-    // socket.set_nagle_enabled(false);
+    socket.set_nagle_enabled(false);
     loop {
         info!("Listening on TCP:22...");
         if let Err(_) = socket.accept(22).await {


### PR DESCRIPTION
This gives a fair bit better performance with test_get_file_long.sh to localhost, it now goes 80MB/sec (with sftp -vvv turned down). Disabling nagle was a TODO I'd accidentally deleted - I was waiting for a new embassy-net.

The async waker fix is for a problem where at certain settings I would see a stall around 65MB/100MB, debugged with a lot of print debugging.

@jubeormk1 