### PR TITLE
Remove output pipe from sftp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,7 +3338,6 @@ version = "0.1.3"
 dependencies = [
  "bbqueue",
  "embassy-futures",
- "embassy-sync",
  "embedded-io-async 0.7.0",
  "log",
  "num_enum",

--- a/demo/sftp/std/src/demosftpserver.rs
+++ b/demo/sftp/std/src/demosftpserver.rs
@@ -1,6 +1,8 @@
 use crate::demofilehandlemanager::DemoFileHandleManager;
 use crate::stdhelpers::{DirEntriesCollection, get_file_attrs};
 
+use embedded_io_async::Write;
+use sunset_sftp::embedded_io_async;
 use sunset_sftp::server::DirReadReplyFinished;
 use sunset_sftp::{
     error::SftpResult,
@@ -281,12 +283,12 @@ impl<OFH: OpaqueFileHandle + InitFileHandler> SftpServer<OFH>
         }
     }
 
-    async fn read<const N: usize>(
+    async fn read<W: Write>(
         &mut self,
         opaque_file_handle: &OFH,
         offset: u64,
         len: u32,
-        reply: ReadHeaderReply<'_, N>,
+        mut reply: ReadHeaderReply<'_, '_, W>,
     ) -> SftpResult<ReadReplyFinished> {
         let PrivatePathHandle::File(private_file_handle) = self
             .handles_manager
@@ -356,7 +358,7 @@ impl<OFH: OpaqueFileHandle + InitFileHandler> SftpServer<OFH>
         let mut accumulated_offset = offset;
 
         let finished = data_reply
-            .send_data(|limited_sender| async move {
+            .send_data(|mut limited_sender| async move {
                 loop {
                     match limited_sender.completed() {
                         Some(completed_token) => return Ok(completed_token),
@@ -434,10 +436,10 @@ impl<OFH: OpaqueFileHandle + InitFileHandler> SftpServer<OFH>
         }
     }
 
-    async fn readdir<const N: usize>(
+    async fn readdir<W: Write>(
         &mut self,
         opaque_dir_handle: &OFH,
-        reply: DirReadHeaderReply<'_, N>,
+        mut reply: DirReadHeaderReply<'_, '_, W>,
     ) -> SftpOpResult<DirReadReplyFinished> {
         info!("read dir for {:?}", opaque_dir_handle);
 

--- a/demo/sftp/std/src/stdhelpers.rs
+++ b/demo/sftp/std/src/stdhelpers.rs
@@ -1,3 +1,5 @@
+use embedded_io_async::Write;
+use sunset_sftp::embedded_io_async;
 /// Helpers structures intended to for environment with `std` available, specially linux.
 ///
 /// The collection helps with directory and directory items enumeration, description
@@ -77,10 +79,13 @@ impl DirEntriesCollection {
         self.count
     }
 
-    pub(crate) async fn send_entries<const N: usize>(
+    pub(crate) async fn send_entries<W>(
         &self,
-        data_reply: DirReadDataReply<'_, N>,
-    ) -> SftpOpResult<DirReadReplyFinished> {
+        data_reply: DirReadDataReply<'_, '_, W>,
+    ) -> SftpOpResult<DirReadReplyFinished>
+    where
+        W: Write,
+    {
         if self.entries.is_empty() {
             return Err(StatusCode::SSH_FX_EOF);
         }

--- a/sftp/Cargo.toml
+++ b/sftp/Cargo.toml
@@ -23,6 +23,5 @@ embedded-io-async.workspace = true
 num_enum = { version = "0.7.4", default-features = false }
 paste = "=1.0.15" # Last released version
 log.workspace = true
-embassy-sync.workspace = true
 embassy-futures.workspace = true
 bbqueue = "0.7.0"

--- a/sftp/src/proto.rs
+++ b/sftp/src/proto.rs
@@ -1017,11 +1017,10 @@ mod proto_tests {
 
         let mut sink = SftpSink::new(&mut buff);
         data_packet.encode_response(&mut sink).expect("Failed to encode response");
-        println!(
-            "data_packet encoded_len = {:?}, encoded = {:?}",
-            sink.payload_len(),
-            sink.payload_slice()
-        );
+
+        let len = sink.payload_len();
+        let sl = sink.used_slice();
+        println!("data_packet encoded_len = {:?}, encoded = {:?}", len, sl);
         let mut source = SftpSource::new(sink.used_slice());
         println!("source = {:?}", source);
 
@@ -1079,12 +1078,10 @@ mod proto_tests {
 
         let mut sink = SftpSink::new(&mut buff);
         attr_read_only.enc(&mut sink).unwrap();
-        println!(
-            "attr_read_only encoded_len = {:?}, encoded = {:?}",
-            sink.payload_len(),
-            sink.payload_slice()
-        );
-        let mut source = SftpSource::new(sink.payload_slice());
+        let len = sink.payload_len();
+        let sl = sink.payload_slice();
+        println!("attr_read_only encoded_len = {:?}, encoded = {:?}", len, sl);
+        let mut source = SftpSource::new(sl);
         println!("source = {:?}", source);
 
         let a_r = Attrs::dec(&mut source);

--- a/sftp/src/sftperror.rs
+++ b/sftp/src/sftperror.rs
@@ -37,6 +37,13 @@ pub enum SftpError {
     SunsetError(SunsetError),
 }
 
+impl SftpError {
+    /// Create a `SftpError` from an `embedded_io_async::Error`
+    pub fn from_embedded_io<E: embedded_io_async::Error>(e: E) -> Self {
+        SunsetError::EmbeddedIoError { kind: e.kind() }.into()
+    }
+}
+
 impl From<WireError> for SftpError {
     fn from(value: WireError) -> Self {
         SftpError::WireError(value)

--- a/sftp/src/sftperror.rs
+++ b/sftp/src/sftperror.rs
@@ -60,6 +60,7 @@ impl From<RequestHolderError> for SftpError {
         SftpError::RequestHolderError(value)
     }
 }
+
 // impl From<FileServerError> for SftpError {
 //     fn from(value: FileServerError) -> Self {
 //         SftpError::FileServerError(value)

--- a/sftp/src/sftphandler/mod.rs
+++ b/sftp/src/sftphandler/mod.rs
@@ -6,7 +6,4 @@ pub use sftphandler::SftpHandler;
 pub use sftpoutputchannelhandler::SftpOutputProducer;
 
 #[cfg(test)]
-pub use sftpoutputchannelhandler::SftpOutputPipe;
-
-#[cfg(test)]
 pub use sftpoutputchannelhandler::mock::MockWriter;

--- a/sftp/src/sftphandler/requestholder.rs
+++ b/sftp/src/sftphandler/requestholder.rs
@@ -1,5 +1,5 @@
 use crate::{
-    proto::{MAX_REQUEST_LEN, SftpNum, SftpPacket},
+    proto::{SftpNum, SftpPacket},
     sftpsource::SftpSource,
 };
 
@@ -55,7 +55,7 @@ pub(crate) type RequestHolderResult<T> = Result<T, RequestHolderError>;
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct RequestHolder<'a> {
     /// The buffer used to contain the data for the request
-    buffer: &'a mut [u8; MAX_REQUEST_LEN],
+    buffer: &'a mut [u8],
     /// The index of the last byte in the buffer containing usable data
     buffer_fill_index: usize,
     /// Number of bytes appended in a previous `try_hold` or `try_append_for_valid_request` slice
@@ -67,7 +67,7 @@ pub(crate) struct RequestHolder<'a> {
 impl<'a> RequestHolder<'a> {
     /// The buffer will be used to hold a full request. Choose a
     /// reasonable size for this buffer.
-    pub(crate) fn new(buffer: &'a mut [u8; MAX_REQUEST_LEN]) -> Self {
+    pub(crate) fn new(buffer: &'a mut [u8]) -> Self {
         RequestHolder {
             buffer: buffer,
             buffer_fill_index: 0,
@@ -299,6 +299,7 @@ impl<'a> RequestHolder<'a> {
 #[cfg(test)]
 mod local_test {
     use super::*;
+    use crate::proto::MAX_REQUEST_LEN;
 
     #[cfg(test)]
     extern crate std;

--- a/sftp/src/sftphandler/sftphandler.rs
+++ b/sftp/src/sftphandler/sftphandler.rs
@@ -16,7 +16,7 @@ use sunset::Error as SunsetError;
 use sunset::sshwire::{SSHSource, WireError};
 
 use core::u32;
-use embedded_io_async::{Error, Write};
+use embedded_io_async::Write;
 #[allow(unused_imports)]
 use log::{debug, error, info, log, trace, warn};
 
@@ -147,7 +147,7 @@ where
                 let lr = chan_in
                     .read(&mut input)
                     .await
-                    .map_err(|e| SunsetError::from(e.kind()))?;
+                    .map_err(|e| SftpError::from_embedded_io(e))?;
 
                 debug!("SFTP <---- received: {:?} bytes", lr);
                 trace!("SFTP <---- received: {:?}", &input[0..lr]);

--- a/sftp/src/sftphandler/sftphandler.rs
+++ b/sftp/src/sftphandler/sftphandler.rs
@@ -116,10 +116,7 @@ where
     /// the request in the local system
     /// - `request_buffer`: used to deal with fragmented
     /// packets during [`SftpHandler::process_loop`]
-    pub fn new(
-        file_server: &'a mut S,
-        request_buffer: &'a mut [u8; MAX_REQUEST_LEN],
-    ) -> Self {
+    pub fn new(file_server: &'a mut S, request_buffer: &'a mut [u8]) -> Self {
         SftpHandler {
             file_server,
             state: HandlerState::default(),

--- a/sftp/src/sftphandler/sftphandler.rs
+++ b/sftp/src/sftphandler/sftphandler.rs
@@ -7,18 +7,16 @@ use crate::proto::{
 use crate::server::DirReadHeaderReply;
 use crate::sftperror::SftpResult;
 use crate::sftphandler::requestholder::{RequestHolder, RequestHolderError};
-use crate::sftphandler::sftpoutputchannelhandler::{
-    SftpOutputPipe, SftpOutputProducer,
-};
+use crate::sftphandler::sftpoutputchannelhandler::SftpOutputProducer;
 use crate::sftpserver::{ReadHeaderReply, SftpServer};
 use crate::sftpsource::SftpSource;
 
-use embassy_futures::select::{Either3, select3};
+use embassy_futures::select::{Either, select};
 use sunset::Error as SunsetError;
 use sunset::sshwire::{SSHSource, WireError};
 
 use core::u32;
-use embedded_io_async::Error;
+use embedded_io_async::{Error, Write};
 #[allow(unused_imports)]
 use log::{debug, error, info, log, trace, warn};
 
@@ -72,15 +70,16 @@ enum HandlerState {
 /// Process the raw buffers in and out from a subsystem channel decoding
 /// request and encoding responses
 ///
-/// Parameter (S): It will delegate request to an [`crate::sftpserver::SftpServer`]
+/// Parameter `S`: Will delegate request to an [`crate::sftpserver::SftpServer`]
 /// implemented by the library user taking into account the local system details.
 ///
-/// Parameter (T): Is a type that implements [`crate::handles::OpaqueFileHandle`] that **must** match the type used in the [`crate::sftpserver::SftpServer`] provided in (S)
+/// Parameter `T`: A type that implements [`crate::handles::OpaqueFileHandle`]
+/// that **must** match the type used in the [`crate::sftpserver::SftpServer`] provided in `S`.
 ///
-/// The compiler time constant `BUFFER_OUT_SIZE` is used to define the
-/// size of the output buffer for the subsystem [`embassy_sync::pipe::Pipe`] used
-/// to send responses safely across the instantiated structure.
-///
+/// Parameter `BUFFER_OUT_SIZE` sizes an output buffer to send responses.
+/// Must be sufficiently to create responses such as file entries
+/// (size will depend on maximum file length).
+/// 512 would be a typical small buffer.
 pub struct SftpHandler<'a, T, S, const BUFFER_OUT_SIZE: usize>
 where
     T: OpaqueFileHandle,
@@ -132,17 +131,10 @@ where
     pub async fn process_loop(
         &mut self,
         mut chan_in: impl embedded_io_async::Read,
-        chan_out: impl embedded_io_async::Write,
+        mut chan_out: impl embedded_io_async::Write,
     ) -> SftpResult<()> {
         // A single request should be adequate for progress.
         const INPUT_BUF: usize = MAX_REQUEST_LEN;
-
-        let mut sftp_output_pipe = SftpOutputPipe::<BUFFER_OUT_SIZE>::new();
-
-        let (mut output_consumer, output_producer) =
-            sftp_output_pipe.split(chan_out)?;
-
-        let output_consumer_loop = output_consumer.receive_task();
 
         let buf = SFTPBBQueue::<INPUT_BUF>::new();
 
@@ -172,34 +164,37 @@ where
 
         let processing_loop = async {
             let cons = buf.stream_consumer();
+            let mut out_buf = [0u8; BUFFER_OUT_SIZE];
+
             loop {
                 let input = cons.wait_read().await;
                 trace!("SFTP: About to read bytes from SSH Channel");
 
-                let consumed = self.process(&input, &output_producer).await?;
+                let mut output_producer =
+                    SftpOutputProducer::new(&mut chan_out, &mut out_buf);
+                let consumed = self.process(&input, &mut output_producer).await?;
                 input.release(consumed);
             }
         };
-        match select3(read_loop, processing_loop, output_consumer_loop).await {
-            Either3::First(r) => {
+        match select(read_loop, processing_loop).await {
+            Either::First(r) => {
                 error!("Read returned: {:?}", r);
                 r
             }
-            Either3::Second(r) => {
+            Either::Second(r) => {
                 error!("Processing returned: {:?}", r);
-                r
-            }
-            Either3::Third(r) => {
-                error!("Output consumer returned: {:?}", r);
                 r
             }
         }
     }
 
-    async fn process_validated_request(
+    async fn process_validated_request<W>(
         &mut self,
-        output_producer: &SftpOutputProducer<'_, BUFFER_OUT_SIZE>,
-    ) -> SftpResult<()> {
+        output_producer: &mut SftpOutputProducer<'_, W>,
+    ) -> SftpResult<()>
+    where
+        W: Write,
+    {
         let Some(sftp_packet) = self.request_holder.valid_request() else {
             return Err(SunsetError::bug().into());
         };
@@ -208,11 +203,12 @@ where
                 debug!("Read request: {:?}", sftp_packet);
 
                 let reply = ReadHeaderReply::new(req_id, output_producer);
-                if let Err(error) = self
+                let res = self
                     .file_server
                     .read(&T::try_from(&read.handle)?, read.offset, read.len, reply)
-                    .await
-                {
+                    .await;
+
+                if let Err(error) = res {
                     error!("Error reading data: {:?}", error);
                     if let SftpError::FileServerError(status) = error {
                         output_producer
@@ -405,11 +401,14 @@ where
     /// - Serializes an answer in `output_producer`
     ///
     /// Returns the amount of data consumed.
-    async fn process(
+    async fn process<W>(
         &mut self,
         buffer_in: &[u8],
-        output_producer: &SftpOutputProducer<'_, BUFFER_OUT_SIZE>,
-    ) -> SftpResult<usize> {
+        output_producer: &mut SftpOutputProducer<'_, W>,
+    ) -> SftpResult<usize>
+    where
+        W: Write,
+    {
         /*
         Possible scenarios:
             - Init: The init handshake has to be performed. Only Init packet is accepted. NAV(Idle)
@@ -644,7 +643,7 @@ where
                     // At this point the assumption is that the request holder will contain
                     // a full valid request (Lets call this an invariant)
 
-                    self.process_validated_request(&output_producer).await?;
+                    self.process_validated_request(output_producer).await?;
                     // Return so that more input can be read if possible.
                     return Ok(buffer_in.len() - buf.len());
                 }
@@ -658,6 +657,9 @@ where
             }
             trace!("Process will check buf len {:?}", buf.len());
         }
+
+        output_producer.flush().await?;
+
         debug!("Whole buffer processed. Getting more data");
         debug_assert_eq!(buf.len(), 0);
         Ok(buffer_in.len())

--- a/sftp/src/sftphandler/sftpoutputchannelhandler.rs
+++ b/sftp/src/sftphandler/sftpoutputchannelhandler.rs
@@ -20,10 +20,7 @@ impl<'a, W: Write> SftpOutputProducer<'a, W> {
     // TODO: if/when rust async drop is implemented, flush there.
     /// Flush output
     pub async fn flush(&mut self) -> SftpResult<()> {
-        self.writer
-            .flush()
-            .await
-            .map_err(|e| SunsetError::EmbeddedIoError { kind: e.kind() }.into())
+        self.writer.flush().await.map_err(|e| SftpError::from_embedded_io(e))
     }
 
     /// Sends the data encoded in the provided [`SftpSink`] without including

--- a/sftp/src/sftphandler/sftpoutputchannelhandler.rs
+++ b/sftp/src/sftphandler/sftpoutputchannelhandler.rs
@@ -1,9 +1,8 @@
-use crate::error::SftpResult;
+use crate::error::{SftpError, SftpResult};
 use crate::proto::{ReqId, SftpPacket, Status, StatusCode};
 use crate::sftpsink::SftpSink;
 
-use embedded_io_async::{Error, Write};
-use sunset::Error as SunsetError;
+use embedded_io_async::Write;
 
 use log::{debug, trace};
 
@@ -32,10 +31,7 @@ impl<'a, W: Write> SftpOutputProducer<'a, W> {
     ///
     /// Use this when you are sending chunks of data after a valid header
     pub async fn send_data(&mut self, buf: &[u8]) -> SftpResult<()> {
-        self.writer
-            .write_all(buf)
-            .await
-            .map_err(|e| SunsetError::EmbeddedIoError { kind: e.kind() }.into())
+        self.writer.write_all(buf).await.map_err(|e| SftpError::from_embedded_io(e))
     }
 
     /// Simplifies the task of sending a status response to the client.
@@ -63,7 +59,7 @@ impl<'a, W: Write> SftpOutputProducer<'a, W> {
         self.writer
             .write_all(&sink.used_slice())
             .await
-            .map_err(|e| SunsetError::EmbeddedIoError { kind: e.kind() }.into())
+            .map_err(|e| SftpError::from_embedded_io(e))
     }
 
     pub fn sink(&mut self) -> (SftpSink<'_>, &mut W) {

--- a/sftp/src/sftphandler/sftpoutputchannelhandler.rs
+++ b/sftp/src/sftphandler/sftpoutputchannelhandler.rs
@@ -1,213 +1,46 @@
-use crate::error::{SftpError, SftpResult};
+use crate::error::SftpResult;
 use crate::proto::{ReqId, SftpPacket, Status, StatusCode};
-use crate::server::SftpSink;
+use crate::sftpsink::SftpSink;
 
-use embassy_sync::pipe::{Pipe, Reader as PipeReader, Writer as PipeWriter};
 use embedded_io_async::{Error, Write};
 use sunset::Error as SunsetError;
-use sunset_async::SunsetRawMutex;
-
-#[cfg(debug_assertions)]
-use core::sync::atomic::AtomicUsize;
-#[cfg(debug_assertions)]
-use core::sync::atomic::Ordering;
 
 use log::{debug, trace};
 
-#[cfg(debug_assertions)]
-type Counter = AtomicUsize;
-
-pub struct SftpOutputPipe<const N: usize> {
-    pipe: Pipe<SunsetRawMutex, N>,
-    split: bool,
-    #[cfg(debug_assertions)]
-    counter_send: Counter,
+/// Handle to send data to an output channel.
+pub struct SftpOutputProducer<'a, W: Write> {
+    writer: &'a mut W,
+    buf: &'a mut [u8],
 }
 
-/// M: SunsetSunsetRawMutex
-impl<const N: usize> SftpOutputPipe<N> {
-    /// Creates an empty SftpOutputPipe.
-    /// The output channel will be consumed during the split call
-    ///
-    ///  Usage:
-    ///
-    /// let output_pipe = SftpOutputPipe::<NoopSunsetRawMutex, 1024>::new();
-    ///
-    pub fn new() -> Self {
-        SftpOutputPipe {
-            pipe: Pipe::new(),
-            #[cfg(debug_assertions)]
-            counter_send: Counter::new(0),
-            split: false,
-        }
+impl<'a, W: Write> SftpOutputProducer<'a, W> {
+    pub fn new(writer: &'a mut W, buf: &'a mut [u8]) -> Self {
+        Self { writer, buf }
     }
 
-    /// Get a Consumer and Producer pair so the producer can send data to the
-    /// output channel without mutable borrows.
-    ///
-    /// The [`SftpOutputConsumer`] needs to be running to write data to the
-    /// provided writer.
-    ///
-    /// ## Lifetimes
-    /// The lifetime `'a` ties the pipe reader (from `self`) to the consumer.
-    /// The writer `W` carries its own lifetime if needed (e.g. `ChanOut<'a>`).
-    pub fn split<'a, W>(
-        &'a mut self,
-        ssh_chan_out: W,
-    ) -> SftpResult<(SftpOutputConsumer<'a, W, N>, SftpOutputProducer<'a, N>)>
-    where
-        W: Write,
-    {
-        if self.split {
-            return Err(SftpError::AlreadyInitialized);
-        }
-        self.split = true;
-        let (reader, writer) = self.pipe.split();
-        Ok((
-            SftpOutputConsumer {
-                pipe_reader: reader,
-                ssh_chan_out,
-                #[cfg(debug_assertions)]
-                counter: 0,
-            },
-            SftpOutputProducer {
-                writer,
-                #[cfg(debug_assertions)]
-                counter: &self.counter_send,
-            },
-        ))
-    }
-}
-
-/// Consumer that pipes data received from a [`PipeReader`] into a writer
-/// implementing [`Write`].
-///
-/// N is the length of the
-/// [PipeReader](https://docs.embassy.dev/embassy-sync/git/default/pipe/struct.Reader.html)
-/// buffer used to receive the data.
-pub(crate) struct SftpOutputConsumer<'a, W, const N: usize> {
-    pipe_reader: PipeReader<'a, SunsetRawMutex, N>,
-    /// The writer where the channel data is written to
-    ssh_chan_out: W,
-    /// Only used for debug purposes
-    #[cfg(debug_assertions)]
-    counter: usize,
-}
-
-impl<'a, W, const N: usize> SftpOutputConsumer<'a, W, N>
-where
-    W: Write,
-{
-    /// Run it to start the piping
-    pub async fn receive_task(&mut self) -> SftpResult<()> {
-        debug!("Running SftpOutout Consumer Reader task");
-        let mut buf = [0u8; N];
-        loop {
-            let rl = self.pipe_reader.read(&mut buf).await;
-            if rl == 0 {
-                debug!("Output Consumer: Pipe closed, stopping receiving task");
-                return Ok(());
-            }
-            #[cfg(debug_assertions)]
-            {
-                self.counter = self.counter.wrapping_add(buf.len());
-
-                debug!(
-                    "Output Consumer: ---> Reads {rl} bytes. Total {}",
-                    self.counter
-                );
-            }
-            let mut scanning_buffer = &buf[..rl];
-
-            // Replaced write_all with loop to handle partial writes to discard issues in write_all
-            while scanning_buffer.len() > 0 {
-                trace!(
-                    "Output Consumer: Tries to write {:?} bytes to ChanOut",
-                    scanning_buffer.len()
-                );
-                let wl = self
-                    .ssh_chan_out
-                    .write(scanning_buffer)
-                    .await
-                    .map_err(|e| SunsetError::from(e.kind()))?;
-                debug!("Output Consumer: Written {:?} bytes ", wl);
-                if wl < scanning_buffer.len() {
-                    debug!(
-                        "Output Consumer: ChanOut accepted only part of the buffer"
-                    );
-                }
-                trace!(
-                    "Output Consumer: Bytes written {:?}",
-                    &scanning_buffer[..wl]
-                );
-                scanning_buffer = &scanning_buffer[wl..];
-            }
-            debug!("Output Consumer: Finished writing all bytes in read buffer");
-        }
+    // TODO: if/when rust async drop is implemented, flush there.
+    /// Flush output
+    pub async fn flush(&mut self) -> SftpResult<()> {
+        self.writer
+            .flush()
+            .await
+            .map_err(|e| SunsetError::EmbeddedIoError { kind: e.kind() }.into())
     }
 
-    /// Consumes the consumer and returns the underlying writer.
-    /// Useful in tests to inspect what was written.
-    #[cfg(test)]
-    pub fn into_inner(self) -> W {
-        self.ssh_chan_out
-    }
-
-    /// Reads one batch of bytes from the pipe and writes them to the inner
-    /// writer. Unlike [`receive_task`], this does not loop — it returns after
-    /// a single read, so it won't block waiting for more data.
-    ///
-    /// Intended for tests only.
-    #[cfg(test)]
-    pub async fn receive_once(&mut self) -> SftpResult<()> {
-        let mut buf = [0u8; N];
-        let rl = self.pipe_reader.read(&mut buf).await;
-        if rl == 0 {
-            return Ok(());
-        }
-        let mut scanning_buffer = &buf[..rl];
-        while scanning_buffer.len() > 0 {
-            let wl = self
-                .ssh_chan_out
-                .write(scanning_buffer)
-                .await
-                .map_err(|e| SunsetError::from(e.kind()))?;
-            scanning_buffer = &scanning_buffer[wl..];
-        }
-        Ok(())
-    }
-}
-
-/// Producer used to send data to a [`ChanOut`] without the restrictions
-/// of mutable borrows
-///
-/// Under the hood it uses an
-/// [embassy_sync Pipe](https://docs.embassy.dev/embassy-sync/git/default/pipe/struct.Pipe.html)
-/// where N is the pipe buffer length in bytes
-pub struct SftpOutputProducer<'a, const N: usize> {
-    writer: PipeWriter<'a, SunsetRawMutex, N>,
-    #[cfg(debug_assertions)]
-    counter: &'a Counter,
-}
-impl<'a, const N: usize> SftpOutputProducer<'a, N> {
     /// Sends the data encoded in the provided [`SftpSink`] without including
     /// the size.
     ///
     /// Use this when you are sending chunks of data after a valid header
-    pub async fn send_data(&self, buf: &[u8]) -> SftpResult<()> {
-        Self::send_buffer(
-            &self.writer,
-            &buf,
-            #[cfg(debug_assertions)]
-            &self.counter,
-        )
-        .await;
-        Ok(())
+    pub async fn send_data(&mut self, buf: &[u8]) -> SftpResult<()> {
+        self.writer
+            .write_all(buf)
+            .await
+            .map_err(|e| SunsetError::EmbeddedIoError { kind: e.kind() }.into())
     }
 
     /// Simplifies the task of sending a status response to the client.
     pub async fn send_status(
-        &self,
+        &mut self,
         req_id: ReqId,
         status: StatusCode,
         msg: &'static str,
@@ -222,53 +55,19 @@ impl<'a, const N: usize> SftpOutputProducer<'a, N> {
     }
 
     /// Sends a SFTP Packet into the channel out, including the length field
-    pub async fn send_packet(&self, packet: &SftpPacket<'_>) -> SftpResult<()> {
-        let mut buf = [0u8; N];
-        let mut sink = SftpSink::new(&mut buf);
+    pub async fn send_packet(&mut self, packet: &SftpPacket<'_>) -> SftpResult<()> {
+        let mut sink = SftpSink::new(self.buf);
         packet.encode_response(&mut sink)?;
         debug!("Output Producer: Sending packet {:?}", packet);
-        Self::send_buffer(
-            &self.writer,
-            &sink.used_slice(),
-            #[cfg(debug_assertions)]
-            &self.counter,
-        )
-        .await;
-        Ok(())
+
+        self.writer
+            .write_all(&sink.used_slice())
+            .await
+            .map_err(|e| SunsetError::EmbeddedIoError { kind: e.kind() }.into())
     }
 
-    /// Internal associated method to log the writes to the pipe
-    async fn send_buffer(
-        writer: &PipeWriter<'a, SunsetRawMutex, N>,
-        buf: &[u8],
-        #[cfg(debug_assertions)] counter: &Counter,
-    ) {
-        #[cfg(debug_assertions)]
-        {
-            let total = counter.load(Ordering::Relaxed).wrapping_add(buf.len());
-            counter.store(total, Ordering::Relaxed);
-
-            debug!(
-                "Output Producer: <--- Sends {:?} bytes. Total {total}",
-                buf.len()
-            );
-            trace!("Output Producer: Sending buffer {:?}", buf);
-        }
-
-        let mut buf = buf;
-        loop {
-            if buf.len() == 0 {
-                break;
-            }
-
-            trace!("Output Producer: Tries to send {:?} bytes", buf.len());
-            let bytes_sent = writer.write(&buf).await;
-            buf = &buf[bytes_sent..];
-            trace!(
-                "Output Producer: sent {bytes_sent:?}. {:?} bytes remain ",
-                buf.len()
-            );
-        }
+    pub fn sink(&mut self) -> (SftpSink<'_>, &mut W) {
+        (SftpSink::new(self.buf), self.writer)
     }
 }
 

--- a/sftp/src/sftpserver/readdirreplies.rs
+++ b/sftp/src/sftpserver/readdirreplies.rs
@@ -1,12 +1,12 @@
 use crate::{
-    error::{SftpError, SftpResult},
-    proto::{
-        ENCODED_SSH_FXP_NAME_HEADER, MAX_NAME_ENTRY_SIZE, NameEntry, ReqId, SftpNum,
-    },
+    error::SftpResult,
+    proto::{ENCODED_SSH_FXP_NAME_HEADER, NameEntry, ReqId, SftpNum},
     protocol::StatusCode,
-    server::SftpSink,
     sftphandler::SftpOutputProducer,
+    sftpsink::SftpSink,
 };
+
+use embedded_io_async::Write;
 
 use sunset::sshwire::SSHEncode;
 
@@ -16,58 +16,23 @@ use log::{debug, error};
 ///
 /// Enforces the correct sequence of sending a DirRead reply,
 /// which consists of first sending a header with the announced data length using [`DirReadHeaderReply::send_header`] and then sending the data itself using [`DirReadDataReply::send_data`].
-pub struct DirReadHeaderReply<'g, const N: usize> {
+pub struct DirReadHeaderReply<'a, 'p, W: Write> {
     /// The request Id that will be use`d in the response
     req_id: ReqId,
-    /// Immutable writer
-    chan_out: &'g SftpOutputProducer<'g, N>,
+    chan_out: &'a mut SftpOutputProducer<'p, W>,
 }
 
-impl<'g, const N: usize> DirReadHeaderReply<'g, N> {
+impl<'a, 'p, W: Write> DirReadHeaderReply<'a, 'p, W> {
     /// Creates a new DirReadHeaderReply with the given request ID and output channel.
     ///
     /// It is meant to be called in [`SftpHandler`] and used to call a method of the [`SftpServer`] that requires a read reply header, such as [`SftpServer::readdir`]
     pub(crate) fn new(
         req_id: ReqId,
-        chan_out: &'g SftpOutputProducer<'g, N>,
+        chan_out: &'a mut SftpOutputProducer<'p, W>,
     ) -> Self {
         Self { req_id, chan_out }
     }
 
-    // /// Sends the header for a read reply with the given data length.
-    // ///
-    // /// Once used, the only way to obtain a [`DirReadReplyFinished`] is by using its returned value.
-    // pub async fn send_header(
-    //     self,
-    //     data_len: u32,
-    // ) -> SftpResult<DirReadDataReply<'g, N>> {
-    //     debug!(
-    //         "DirReadReply: Sending header for request id {:?}: data length = {:?}",
-    //         self.req_id, data_len
-    //     );
-    //     let mut s = [0u8; N];
-    //     let mut sink = SftpSink::new(&mut s);
-
-    //     let payload = DirReadHeaderReply::<N>::encode_data_header(
-    //         &mut sink,
-    //         self.req_id,
-    //         data_len,
-    //     )
-    //     .map_err(|err| {
-    //         error!("WireError: {:?}", err);
-    //         StatusCode::SSH_FX_FAILURE
-    //     })?;
-
-    //     debug!(
-    //         "Sending header:  len = {:?}, content = {:?}",
-    //         payload.len(),
-    //         payload
-    //     );
-    //     // Sending payload_slice since we are not making use of the sink sftpPacket length calculation
-    //     self.chan_out.send_data(payload).await?;
-
-    //     Ok(DirReadDataReply::new(self.req_id, data_len, self.chan_out))
-    // }
     /// Sends the header for a read reply with the given data length.
     ///
     /// Once used, the only way to obtain a [`DirReadReplyFinished`] is by using its returned value.
@@ -75,32 +40,27 @@ impl<'g, const N: usize> DirReadHeaderReply<'g, N> {
         self,
         data_len: u32,
         count: u32,
-    ) -> SftpResult<DirReadDataReply<'g, N>> {
+    ) -> SftpResult<DirReadDataReply<'a, 'p, W>> {
         debug!(
             "DirReadReply: Sending header for request id {:?}: data length = {:?}",
             self.req_id, data_len
         );
-        let mut s = [0u8; N];
-        let mut sink = SftpSink::new(&mut s);
 
-        let payload = DirReadHeaderReply::<N>::encode_header(
-            &mut sink,
-            self.req_id,
-            data_len,
-            count,
-        )
-        .map_err(|err| {
-            error!("WireError: {:?}", err);
-            StatusCode::SSH_FX_FAILURE
-        })?;
+        let (mut sink, w) = self.chan_out.sink();
+        Self::encode_header(&mut sink, self.req_id, data_len, count).map_err(
+            |err| {
+                error!("WireError: {:?}", err);
+                StatusCode::SSH_FX_FAILURE
+            },
+        )?;
 
-        debug!(
-            "Sending header:  len = {:?}, content = {:?}",
-            payload.len(),
-            payload
-        );
+        // debug!(
+        //     "Sending header:  len = {:?}, content = {:?}",
+        //     payload.len(),
+        //     payload
+        // );
         // Sending payload_slice since we are not making use of the sink sftpPacket length calculation
-        self.chan_out.send_data(payload).await?;
+        sink.send(w).await?;
 
         Ok(DirReadDataReply::new(self.req_id, data_len, self.chan_out))
     }
@@ -108,17 +68,17 @@ impl<'g, const N: usize> DirReadHeaderReply<'g, N> {
     /// Sends an EOF status response for the read request.
     ///
     /// It will return a [`DirReadReplyFinished`] that can be used to represent the state of the successful read reply.
-    pub async fn send_eof(&self) -> SftpResult<DirReadReplyFinished> {
+    pub async fn send_eof(&mut self) -> SftpResult<DirReadReplyFinished> {
         self.chan_out.send_status(self.req_id, StatusCode::SSH_FX_EOF, "").await?;
         Ok(DirReadReplyFinished::new(self.req_id))
     }
 
     fn encode_header(
-        sink: &'g mut SftpSink<'g>,
+        sink: &mut SftpSink,
         req_id: ReqId,
         data_len: u32,
         count: u32,
-    ) -> Result<&'g [u8], SftpError> {
+    ) -> SftpResult<()> {
         // length field
         (data_len + ENCODED_SSH_FXP_NAME_HEADER).enc(sink)?;
         // packet type (1)
@@ -126,7 +86,7 @@ impl<'g, const N: usize> DirReadHeaderReply<'g, N> {
         // request id (4)
         req_id.enc(sink)?;
         count.enc(sink)?;
-        Ok(sink.payload_slice())
+        Ok(())
     }
 }
 
@@ -145,42 +105,33 @@ impl DirReadReplyFinished {
 
 /// Helper struct to enforce the correct sequence of sending directory items in a readdir
 ///  reply, which consists of sending items until the announced data length is reached.
-pub struct LimitedDirSender<'g, const N: usize> {
+pub struct LimitedDirSender<'a, 'g, W: Write> {
     /// Immutable writer
-    chan_out: &'g SftpOutputProducer<'g, N>,
+    chan_out: &'a mut SftpOutputProducer<'g, W>,
     /// remaining data length to be sent as announced in [`DirReadDataReply::send_data`]
     ///  when calling the closure with this LimitedDirSender as an argument.
     remaining: u32,
 }
 
-impl<'g, const N: usize> LimitedDirSender<'g, N> {
-    fn new(chan_out: &'g SftpOutputProducer<'g, N>, limit: u32) -> Self {
+impl<'a, 'g, W: Write> LimitedDirSender<'a, 'g, W> {
+    fn new(chan_out: &'a mut SftpOutputProducer<'g, W>, limit: u32) -> Self {
         Self { chan_out, remaining: limit }
     }
 
     /// Sends a directory item to the client as a [`NameEntry`]
     ///
     /// Call this
-    pub async fn send_item(
-        &mut self,
-        name_entry: &NameEntry<'_>,
-    ) -> SftpResult<u32> {
-        let mut buffer = [0u8; MAX_NAME_ENTRY_SIZE];
-        let mut sftp_sink = SftpSink::new(&mut buffer);
-        name_entry.enc(&mut sftp_sink)?;
-
-        self.send_data(sftp_sink.payload_slice()).await
+    pub async fn send_item(&mut self, name_entry: &NameEntry<'_>) -> SftpResult<()> {
+        let (mut sink, w) = self.chan_out.sink();
+        name_entry.enc(&mut sink)?;
+        let l = sink.send(w).await?;
+        self.remaining -= l;
+        Ok(())
     }
+
     /// Obtains a [`CompleteDirDataSent`] if the announced data length has been completely sent, otherwise returns None.
     pub fn completed(&self) -> Option<CompleteDirDataSent> {
         if self.is_complete() { Some(CompleteDirDataSent) } else { None }
-    }
-
-    async fn send_data(&mut self, buff: &[u8]) -> SftpResult<u32> {
-        let length_to_send = self.remaining.min(buff.len() as u32);
-        self.chan_out.send_data(&buff[..length_to_send as usize]).await?;
-        self.remaining -= length_to_send;
-        Ok(self.remaining)
     }
 
     fn is_complete(&self) -> bool {
@@ -202,32 +153,31 @@ pub struct CompleteDirDataSent;
 ///  which consists of first sending a header with the announced data length
 /// using [`DirReadHeaderReply::send_header`] and then sending the data
 ///  itself using [`DirReadDataReply::send_data`].
-pub struct DirReadDataReply<'g, const N: usize> {
+pub struct DirReadDataReply<'a, 'g, W: Write> {
     /// The request Id that will be use`d in the response
     req_id: ReqId,
     /// Length of data to be sent as announced in [`DirReadHeaderReply::send_header`]
     data_len: u32,
-    /// Immutable writer
-    chan_out: &'g SftpOutputProducer<'g, N>,
+    chan_out: &'a mut SftpOutputProducer<'g, W>,
 }
 
-impl<'g, const N: usize> DirReadDataReply<'g, N> {
+impl<'a, 'g, W: Write> DirReadDataReply<'a, 'g, W> {
     pub(crate) fn new(
         req_id: ReqId,
         data_len: u32,
-        chan_out: &'g SftpOutputProducer<'g, N>,
+        chan_out: &'a mut SftpOutputProducer<'g, W>,
     ) -> Self {
         Self { req_id, chan_out, data_len }
     }
 
-    /// It provides a closure-based API where the user can send multiple [`NameEntry`]s of data until the announced data length is reached.
+    /// A closure-based API where the user can send multiple [`NameEntry`]s of data until the announced data length is reached.
     ///
     /// It can only be called once, since it consumes self, and it returns a [`DirReadReplyFinished`]
     /// that can be used to represent the state of the successful read reply.
     pub async fn send_data<F, Fut>(self, f: F) -> SftpResult<DirReadReplyFinished>
     where
-        F: FnOnce(LimitedDirSender<'g, N>) -> Fut,
-        Fut: core::future::Future<Output = SftpResult<CompleteDirDataSent>>,
+        F: FnOnce(LimitedDirSender<'a, 'g, W>) -> Fut,
+        Fut: Future<Output = SftpResult<CompleteDirDataSent>>,
     {
         let dir_sender = LimitedDirSender::new(self.chan_out, self.data_len);
         f(dir_sender).await?;
@@ -244,7 +194,8 @@ mod enforcing_process_tests {
     use crate::{
         proto::{Attrs, Filename, NameEntry},
         server::helpers,
-        sftphandler::{MockWriter, SftpOutputPipe},
+        sftperror::SftpError,
+        sftphandler::{MockWriter, SftpOutputProducer},
     };
 
     extern crate alloc;
@@ -257,28 +208,23 @@ mod enforcing_process_tests {
         const N: usize = 512;
 
         let req_id = ReqId(42);
-        let mut output_pipe = SftpOutputPipe::<N>::new();
-        let mock = MockWriter::new();
-        let (mut consumer, producer) =
-            output_pipe.split(mock).expect("split should succeed");
+        let mut buf = [0u8; N];
+        let mut mock = MockWriter::new();
+        let mut producer = SftpOutputProducer::new(&mut mock, &mut buf);
 
         embassy_futures::block_on(async {
             {
-                let dir_header_reply =
-                    DirReadHeaderReply::<N>::new(req_id, &producer);
+                let mut dir_header_reply =
+                    DirReadHeaderReply::new(req_id, &mut producer);
                 let _finished = dir_header_reply
                     .send_eof()
                     .await
                     .expect("send_eof should succeed returning ReadReplyFinished");
             }
-            drop(producer);
-            // Read exactly the one packet written by send_eof; does not loop.
-            consumer.receive_once().await.unwrap();
         });
 
         // SSH_FXP_STATUS (101) packet for SSH_FX_EOF (1) with req_id 42:
         // [len:4][type:1=101][req_id:4][code:4][msg_len:4][msg][lang_len:4][lang]
-        let mock = consumer.into_inner();
         let buf = &mock.buffer;
         // packet type byte should be 101 (SSH_FXP_STATUS)
         assert_eq!(buf[4], 101, "expected SSH_FXP_STATUS packet type");
@@ -292,10 +238,9 @@ mod enforcing_process_tests {
         const N: usize = 2048;
 
         let req_id = ReqId(42);
-        let mut output_pipe = SftpOutputPipe::<N>::new();
-        let mock = MockWriter::new();
-        let (mut consumer, producer) =
-            output_pipe.split(mock).expect("split should succeed");
+        let mut buf = [0u8; N];
+        let mut mock = MockWriter::new();
+        let mut producer = SftpOutputProducer::new(&mut mock, &mut buf);
 
         // 1. Put together a collection of synthetic directory entries
         let filenames = vec!["file1", "file2", "file3"];
@@ -322,7 +267,7 @@ mod enforcing_process_tests {
         embassy_futures::block_on(async {
             {
                 let dir_header_reply =
-                    DirReadHeaderReply::<N>::new(req_id, &producer);
+                    DirReadHeaderReply::new(req_id, &mut producer);
 
                 // 3. Call send_header with the length of the data to be sent
                 let dir_read_data_reply = dir_header_reply
@@ -345,12 +290,8 @@ mod enforcing_process_tests {
                     .await
                     .expect("send_data should succeed returning ReadReplyFinished");
             }
-            drop(producer);
-            // Read exactly the one packet written by send_eof; does not loop.
-            consumer.receive_once().await.expect("receive_once should succeed");
         });
 
-        let mock = consumer.into_inner();
         let buf = &mock.buffer;
         // packet type byte should be 104 (SSH_FXP_NAME)
         assert_eq!(buf[4], 104, "expected SSH_FXP_NAME packet type");
@@ -378,7 +319,7 @@ pub mod helpers {
     use crate::{
         error::SftpResult,
         proto::{MAX_NAME_ENTRY_SIZE, NameEntry},
-        server::SftpSink,
+        sftpsink::SftpSink,
     };
 
     use sunset::sshwire::SSHEncode;

--- a/sftp/src/sftpserver/readdirreplies.rs
+++ b/sftp/src/sftpserver/readdirreplies.rs
@@ -150,12 +150,12 @@ pub struct LimitedDirSender<'g, const N: usize> {
     chan_out: &'g SftpOutputProducer<'g, N>,
     /// remaining data length to be sent as announced in [`DirReadDataReply::send_data`]
     ///  when calling the closure with this LimitedDirSender as an argument.
-    remaining: core::cell::Cell<u32>,
+    remaining: u32,
 }
 
 impl<'g, const N: usize> LimitedDirSender<'g, N> {
     fn new(chan_out: &'g SftpOutputProducer<'g, N>, limit: u32) -> Self {
-        Self { chan_out, remaining: core::cell::Cell::new(limit) }
+        Self { chan_out, remaining: limit }
     }
 
     /// Sends a directory item to the client as a [`NameEntry`]
@@ -176,18 +176,15 @@ impl<'g, const N: usize> LimitedDirSender<'g, N> {
         if self.is_complete() { Some(CompleteDirDataSent) } else { None }
     }
 
-    async fn send_data(&self, buff: &[u8]) -> SftpResult<u32> {
-        let mut remaining = self.remaining.get();
-
-        let length_to_send = remaining.min(buff.len() as u32);
+    async fn send_data(&mut self, buff: &[u8]) -> SftpResult<u32> {
+        let length_to_send = self.remaining.min(buff.len() as u32);
         self.chan_out.send_data(&buff[..length_to_send as usize]).await?;
-        remaining -= length_to_send;
-        self.remaining.set(remaining);
-        Ok(remaining)
+        self.remaining -= length_to_send;
+        Ok(self.remaining)
     }
 
     fn is_complete(&self) -> bool {
-        self.remaining.get() == 0
+        self.remaining == 0
     }
 }
 

--- a/sftp/src/sftpserver/readreplies.rs
+++ b/sftp/src/sftpserver/readreplies.rs
@@ -2,10 +2,11 @@ use crate::{
     error::{SftpError, SftpResult},
     proto::{ENCODED_SSH_FXP_DATA_HEADER, ReqId, SftpNum},
     protocol::StatusCode,
-    server::SftpSink,
     sftphandler::SftpOutputProducer,
+    sftpsink::SftpSink,
 };
 
+use embedded_io_async::Write;
 use sunset::sshwire::SSHEncode;
 
 use log::debug;
@@ -15,20 +16,19 @@ use log::debug;
 ///
 /// On the corresponding method call will return either a [`crate::sftpserver::ReadDataReply`] or a [`crate::sftpserver::ReadReplyFinished`]
 /// which makes easy to implement correct behavior.
-pub struct ReadHeaderReply<'g, const N: usize> {
+pub struct ReadHeaderReply<'a, 'p, W: Write> {
     /// The request Id that will be used in the response
     req_id: ReqId,
-    /// Immutable writer
-    chan_out: &'g SftpOutputProducer<'g, N>,
+    chan_out: &'a mut SftpOutputProducer<'p, W>,
 }
 
-impl<'g, const N: usize> ReadHeaderReply<'g, N> {
+impl<'a, 'p, W: Write> ReadHeaderReply<'a, 'p, W> {
     /// Creates a new ReadHeaderReply with the given request ID and output channel.
     ///
     /// It is meant to be called in [`crate::SftpHandler`] and used to call a method of the [`crate::sftpserver::SftpServer`] that requires a read reply header, such as [`crate::sftpserver::SftpServer::read`]
     pub(crate) fn new(
         req_id: ReqId,
-        chan_out: &'g SftpOutputProducer<'g, N>,
+        chan_out: &'a mut SftpOutputProducer<'p, W>,
     ) -> Self {
         Self { req_id, chan_out }
     }
@@ -39,27 +39,22 @@ impl<'g, const N: usize> ReadHeaderReply<'g, N> {
     pub async fn send_header(
         self,
         data_len: u32,
-    ) -> SftpResult<ReadDataReply<'g, N>> {
+    ) -> SftpResult<ReadDataReply<'a, 'p, W>> {
         debug!(
             "ReadReply: Sending header for request id {:?}: data length = {:?}",
             self.req_id, data_len
         );
-        let mut s = [0u8; N];
-        let mut sink = SftpSink::new(&mut s);
 
-        let payload = ReadHeaderReply::<N>::encode_data_header(
-            &mut sink,
-            self.req_id,
-            data_len,
-        )?;
+        let (mut sink, w) = self.chan_out.sink();
+        Self::encode_data_header(&mut sink, self.req_id, data_len)?;
 
-        debug!(
-            "Sending header:  len = {:?}, content = {:?}",
-            payload.len(),
-            payload
-        );
+        // debug!(
+        //     "Sending header:  len = {:?}, content = {:?}",
+        //     payload.len(),
+        //     payload
+        // );
         // Sending payload_slice since we are not making use of the sink sftpPacket length calculation
-        self.chan_out.send_data(payload).await?;
+        sink.send(w).await?;
 
         Ok(ReadDataReply::new(self.req_id, data_len, self.chan_out))
     }
@@ -67,16 +62,16 @@ impl<'g, const N: usize> ReadHeaderReply<'g, N> {
     /// Sends an EOF status response for the read request.
     ///
     /// It will return a [`ReadReplyFinished`] that can be used to represent the state of the successful read reply.
-    pub async fn send_eof(&self) -> SftpResult<ReadReplyFinished> {
+    pub async fn send_eof(&mut self) -> SftpResult<ReadReplyFinished> {
         self.chan_out.send_status(self.req_id, StatusCode::SSH_FX_EOF, "").await?;
         Ok(ReadReplyFinished::new(self.req_id))
     }
 
     fn encode_data_header(
-        sink: &'g mut SftpSink<'g>,
+        sink: &mut SftpSink,
         req_id: ReqId,
         data_len: u32,
-    ) -> Result<&'g [u8], SftpError> {
+    ) -> Result<(), SftpError> {
         // length field
         (data_len + ENCODED_SSH_FXP_DATA_HEADER).enc(sink)?;
         // packet type (1)
@@ -85,7 +80,7 @@ impl<'g, const N: usize> ReadHeaderReply<'g, N> {
         req_id.enc(sink)?;
         // data length (4)
         data_len.enc(sink)?;
-        Ok(sink.payload_slice())
+        Ok(())
     }
 }
 
@@ -95,19 +90,19 @@ impl<'g, const N: usize> ReadHeaderReply<'g, N> {
 /// It is used as an argument in the closure passed to [`ReadDataReply::send_data`]
 /// and it is meant to be used by the user to send the data of a read reply in chunks,
 /// without having to worry about sending more data than the announced length.
-pub struct LimitedSender<'g, const N: usize> {
-    chan_out: &'g SftpOutputProducer<'g, N>,
+pub struct LimitedSender<'a, 'g, W: Write> {
+    chan_out: &'a mut SftpOutputProducer<'g, W>,
     remaining: core::cell::Cell<u32>,
 }
 
-impl<'g, const N: usize> LimitedSender<'g, N> {
-    fn new(chan_out: &'g SftpOutputProducer<'g, N>, limit: u32) -> Self {
+impl<'a, 'g, W: Write> LimitedSender<'a, 'g, W> {
+    fn new(chan_out: &'a mut SftpOutputProducer<'g, W>, limit: u32) -> Self {
         Self { chan_out, remaining: core::cell::Cell::new(limit) }
     }
     /// Sends a chunk of data, ensuring that no more than the announced data length is sent.
     ///
     /// It returns the remaining data length that can be sent after this call.
-    pub async fn send_data(&self, buff: &[u8]) -> SftpResult<u32> {
+    pub async fn send_data(&mut self, buff: &[u8]) -> SftpResult<u32> {
         let mut remaining = self.remaining.get();
 
         let length_to_send = remaining.min(buff.len() as u32);
@@ -132,20 +127,19 @@ pub struct CompletedDataSent;
 
 /// This struct is used to represent the state of a read reply after the header has been sent
 /// but before the data has been completely sent or an EOF has been sent
-pub struct ReadDataReply<'g, const N: usize> {
+pub struct ReadDataReply<'a, 'g, W: Write> {
     /// The request Id that will be used in the response
     req_id: ReqId,
-    /// Immutable writer
-    chan_out: &'g SftpOutputProducer<'g, N>,
+    chan_out: &'a mut SftpOutputProducer<'g, W>,
     /// Length of data to be sent as announced in [`ReadHeaderReply::send_header`]
     data_len: u32,
 }
 
-impl<'g, const N: usize> ReadDataReply<'g, N> {
+impl<'a, 'g, W: Write> ReadDataReply<'a, 'g, W> {
     pub(crate) fn new(
         req_id: ReqId,
         data_len: u32,
-        chan_out: &'g SftpOutputProducer<'g, N>,
+        chan_out: &'a mut SftpOutputProducer<'g, W>,
     ) -> Self {
         Self { req_id, chan_out, data_len }
     }
@@ -157,7 +151,7 @@ impl<'g, const N: usize> ReadDataReply<'g, N> {
     /// that can be used to represent the state of the successful read reply.
     pub async fn send_data<F, Fut>(self, f: F) -> SftpResult<ReadReplyFinished>
     where
-        F: FnOnce(LimitedSender<'g, N>) -> Fut,
+        F: FnOnce(LimitedSender<'a, 'g, W>) -> Fut,
         Fut: core::future::Future<Output = SftpResult<CompletedDataSent>>,
     {
         let sender = LimitedSender::new(self.chan_out, self.data_len);
@@ -184,7 +178,7 @@ impl ReadReplyFinished {
 
 #[cfg(test)]
 mod enforcing_process_tests {
-    use crate::sftphandler::{MockWriter, SftpOutputPipe};
+    use crate::sftphandler::MockWriter;
 
     use super::*;
 
@@ -199,10 +193,12 @@ mod enforcing_process_tests {
         let mut buffer = [0u8; N];
         let mut sink = SftpSink::new(&mut buffer);
 
-        let payload =
-            ReadHeaderReply::<N>::encode_data_header(&mut sink, req_id, data_len)
-                .unwrap();
+        ReadHeaderReply::<MockWriter>::encode_data_header(
+            &mut sink, req_id, data_len,
+        )
+        .unwrap();
 
+        let payload = sink.payload_slice();
         assert_eq!(
             data_len + ENCODED_SSH_FXP_DATA_HEADER,
             u32::from_be_bytes(payload[..4].try_into().unwrap())
@@ -214,27 +210,22 @@ mod enforcing_process_tests {
         const N: usize = 512;
 
         let req_id = ReqId(42);
-        let mut output_pipe = SftpOutputPipe::<N>::new();
-        let mock = MockWriter::new();
-        let (mut consumer, producer) =
-            output_pipe.split(mock).expect("split should succeed");
+        let mut buf = [0u8; N];
+        let mut mock = MockWriter::new();
+        let mut producer = SftpOutputProducer::new(&mut mock, &mut buf);
 
         embassy_futures::block_on(async {
             {
-                let header_reply = ReadHeaderReply::<N>::new(req_id, &producer);
+                let mut header_reply = ReadHeaderReply::new(req_id, &mut producer);
                 let _finished = header_reply
                     .send_eof()
                     .await
                     .expect("send_eof should succeed returning ReadReplyFinished");
             }
-            drop(producer);
-            // Read exactly the one packet written by send_eof; does not loop.
-            consumer.receive_once().await.unwrap();
         });
 
         // SSH_FXP_STATUS (101) packet for SSH_FX_EOF (1) with req_id 42:
         // [len:4][type:1=101][req_id:4][code:4][msg_len:4][msg][lang_len:4][lang]
-        let mock = consumer.into_inner();
         let buf = &mock.buffer;
         // packet type byte should be 101 (SSH_FXP_STATUS)
         assert_eq!(buf[4], 101, "expected SSH_FXP_STATUS packet type");
@@ -247,14 +238,13 @@ mod enforcing_process_tests {
         const N: usize = 512;
 
         let req_id = ReqId(42);
-        let mut output_pipe = SftpOutputPipe::<N>::new();
-        let mock = MockWriter::new();
-        let (mut consumer, producer) =
-            output_pipe.split(mock).expect("split should succeed");
+        let mut buf = [0u8; N];
+        let mut mock = MockWriter::new();
+        let mut producer = SftpOutputProducer::new(&mut mock, &mut buf);
 
         embassy_futures::block_on(async {
             {
-                let header_reply = ReadHeaderReply::<N>::new(req_id, &producer);
+                let header_reply = ReadHeaderReply::new(req_id, &mut producer);
 
                 let data_reply = header_reply
                     .send_header(10)
@@ -262,7 +252,7 @@ mod enforcing_process_tests {
                     .expect("send_eof should succeed returning ReadReplyData");
 
                 let _read_reply_finished = data_reply
-                    .send_data(|limited_sender| async move {
+                    .send_data(|mut limited_sender| async move {
                         loop {
                             match limited_sender.completed() {
                                 Some(token) => return Ok(token),
@@ -273,12 +263,8 @@ mod enforcing_process_tests {
                     .await
                     .expect("send_data should succeed returning ReadReplyFinished");
             }
-            drop(producer);
-            // Read exactly the one packet written by send_eof; does not loop.
-            consumer.receive_once().await.expect("receive_once should succeed");
         });
 
-        let mock = consumer.into_inner();
         let buf = &mock.buffer;
         // packet type byte should be 103 (SSH_FXP_DATA)
         assert_eq!(buf[4], 103, "expected SSH_FXP_DATA packet type");

--- a/sftp/src/sftpserver/sftpserver.rs
+++ b/sftp/src/sftpserver/sftpserver.rs
@@ -7,6 +7,8 @@ use crate::{
     proto::{Attrs, StatusCode},
 };
 
+use embedded_io_async::Write;
+
 #[allow(unused_imports)]
 use log::{debug, error, info, log, trace, warn};
 
@@ -82,13 +84,16 @@ where
     /// The len is the number of bytes to read.
     /// The reply is a structure that facilitates the task of sending the response back correctly. See [`ReadHeaderReply`] for more details.
     #[allow(unused)]
-    fn read<const N: usize>(
+    fn read<'g, 'p, W>(
         &mut self,
         opaque_file_handle: &T,
         offset: u64,
         len: u32,
-        reply: ReadHeaderReply<'_, N>,
-    ) -> impl core::future::Future<Output = SftpResult<ReadReplyFinished>> {
+        reply: ReadHeaderReply<'g, 'p, W>,
+    ) -> impl core::future::Future<Output = SftpResult<ReadReplyFinished>>
+    where
+        W: Write,
+    {
         async move {
             log::error!(
                 "SftpServer Read operation not defined: handle = {:?}, offset = {:?}, len = {:?}",
@@ -144,10 +149,10 @@ where
     ///
     ///
     #[allow(unused_variables)]
-    fn readdir<const N: usize>(
+    fn readdir<W: Write>(
         &mut self,
         opaque_dir_handle: &T,
-        reply: DirReadHeaderReply<'_, N>,
+        reply: DirReadHeaderReply<'_, '_, W>,
     ) -> impl core::future::Future<Output = SftpOpResult<DirReadReplyFinished>> {
         async move {
             log::error!(

--- a/sftp/src/sftpsink.rs
+++ b/sftp/src/sftpsink.rs
@@ -1,5 +1,6 @@
-use crate::proto::SFTP_FIELD_LEN_LENGTH;
+use crate::{error::SftpResult, proto::SFTP_FIELD_LEN_LENGTH};
 
+use embedded_io_async::{Error as _, Write};
 use sunset::sshwire::{SSHSink, WireError};
 
 #[allow(unused_imports)]
@@ -51,9 +52,20 @@ impl<'g> SftpSink<'g> {
 
     /// Auxiliary method to allow an immutable reference to the encoded payload
     /// excluding the `u32` length field prepended to it
-    pub fn payload_slice(&self) -> &[u8] {
+    pub fn payload_slice(self) -> &'g [u8] {
         &self.buffer
             [SFTP_FIELD_LEN_LENGTH..SFTP_FIELD_LEN_LENGTH + self.payload_len()]
+    }
+
+    /// Send current payload to a `Write` instance
+    ///
+    /// Returns the length sent
+    pub async fn send<W: Write>(self, mut w: W) -> SftpResult<u32> {
+        let s = self.payload_slice();
+        w.write_all(s)
+            .await
+            .map_err(|e| sunset::Error::EmbeddedIoError { kind: e.kind() })?;
+        Ok(s.len() as u32)
     }
 
     /// Auxiliary method to allow an immutable reference to the full used

--- a/sftp/src/sftpsink.rs
+++ b/sftp/src/sftpsink.rs
@@ -1,6 +1,9 @@
-use crate::{error::SftpResult, proto::SFTP_FIELD_LEN_LENGTH};
+use crate::{
+    error::{SftpError, SftpResult},
+    proto::SFTP_FIELD_LEN_LENGTH,
+};
 
-use embedded_io_async::{Error as _, Write};
+use embedded_io_async::Write;
 use sunset::sshwire::{SSHSink, WireError};
 
 #[allow(unused_imports)]
@@ -62,9 +65,7 @@ impl<'g> SftpSink<'g> {
     /// Returns the length sent
     pub async fn send<W: Write>(self, mut w: W) -> SftpResult<u32> {
         let s = self.payload_slice();
-        w.write_all(s)
-            .await
-            .map_err(|e| sunset::Error::EmbeddedIoError { kind: e.kind() })?;
+        w.write_all(s).await.map_err(|e| SftpError::from_embedded_io(e))?;
         Ok(s.len() as u32)
     }
 


### PR DESCRIPTION
Instead of writing to a pipe, the Write reference can be written directly. This avoids memcpy to/from the pipe.
A couple of BUFFER_OUT_SIZE sized buffers are also removed, along with the Pipe instance.
(BUFFER_OUT_SIZE = 512 bytes for the demo server)
    
This runs slightly slower than before, but seems worthwhile given the removed code and runtime memory saving. 
The performance could be investigated further.
