### PR TITLE
sshwire improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3211,6 +3211,7 @@ dependencies = [
 name = "sunset-sshwire-derive"
 version = "0.2.2"
 dependencies = [
+ "sunset",
  "virtue",
 ]
 

--- a/demo/common/src/config.rs
+++ b/demo/common/src/config.rs
@@ -123,7 +123,7 @@ fn enc_signkey(k: &SignKey, s: &mut dyn SSHSink) -> WireResult<()> {
     // need to add a variant field if we support more key types.
     match k {
         SignKey::Ed25519(k) => k.to_bytes().enc(s),
-        _ => Err(WireError::UnknownVariant),
+        _ => Err(WireError::EncodeUnknown),
     }
 }
 

--- a/src/kex.rs
+++ b/src/kex.rs
@@ -782,9 +782,10 @@ impl SharedSecret {
             }
         }?;
 
-        // TODO: error message on signature failure.
-        let h: &[u8] = kex_out.h.as_ref();
+        // OK unwrap, hash is always sha256. Pending output_size() being const.
+        let h: &[u8; 32] = kex_out.h.as_slice().try_into().unwrap();
         trace!("verify  h {h:02x?}");
+        // TODO: error message on signature failure.
         algos
             .hostsig
             .verify(&p.k_s.0, &h, &p.sig.0)
@@ -846,7 +847,9 @@ impl SharedSecret {
 
         let k_s = Blob(hostkey.pubkey());
         trace!("sign kexreply h {:02x?}", ko.h.as_slice());
-        let sig = hostkey.sign(&ko.h.as_slice())?;
+        // OK unwrap, hash is always sha256.
+        let h: &[u8; 32] = ko.h.as_slice().try_into().unwrap();
+        let sig = hostkey.sign(h)?;
         let sig: Signature = (&sig).into();
         let sig = Blob(sig);
         s.send(packets::KexDHReply { k_s, q_s, sig })

--- a/src/namelist.rs
+++ b/src/namelist.rs
@@ -76,7 +76,7 @@ impl SSHEncode for &LocalNames {
             + names.len().saturating_sub(1);
         (strlen as u32).enc(s)?;
         for i in 0..names.len() {
-            names[i].as_bytes().enc(s)?;
+            s.push(names[i].as_bytes())?;
             if i < names.len() - 1 {
                 b','.enc(s)?;
             }

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -10,8 +10,7 @@ use {
     log::{debug, error, info, log, trace, warn},
 };
 
-use core::fmt;
-use core::fmt::{Debug, Display};
+use core::fmt::{self, Debug};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
@@ -25,7 +24,7 @@ use crate::*;
 use namelist::NameList;
 use sign::{OwnedSig, SigType};
 use sshnames::*;
-use sshwire::{BinString, Blob, TextString};
+use sshwire::{BinString, Blob, TextString, Unknown};
 use sshwire::{SSHDecode, SSHEncode, SSHSink, SSHSource, WireError, WireResult};
 
 #[cfg(feature = "rsa")]
@@ -949,46 +948,6 @@ pub struct DirectTcpip<'a> {
     pub port: u32,
     pub origin: TextString<'a>,
     pub origin_port: u32,
-}
-
-/// Placeholder for unknown method names.
-///
-/// These are sometimes non-fatal and
-/// need to be handled by the relevant code, for example newly invented pubkey types.
-/// This is deliberately not `SSHEncode`, we only receive it. sshwire-derive will
-/// automatically create instances.
-#[derive(Clone, PartialEq)]
-pub struct Unknown<'a>(pub &'a [u8]);
-
-impl<'a> Unknown<'a> {
-    pub fn new(u: &'a [u8]) -> Self {
-        let u = Unknown(u);
-        trace!("saw unknown variant \"{u}\"");
-        u
-    }
-}
-
-impl Display for Unknown<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Ok(s) = sshwire::try_as_ascii_str(self.0) {
-            f.write_str(s)
-        } else {
-            write!(f, "non-ascii {:02x?}", self.0)
-        }
-    }
-}
-
-impl Debug for Unknown<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Display::fmt(self, f)
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'arb: 'a, 'a> Arbitrary<'arb> for Unknown<'a> {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'arb>) -> arbitrary::Result<Self> {
-        Ok(Self(arbitrary::Arbitrary::arbitrary(u)?))
-    }
 }
 
 /// State to be passed to decoding.

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -25,7 +25,6 @@ use crate::*;
 use namelist::NameList;
 use sign::{OwnedSig, SigType};
 use sshnames::*;
-use sshwire::SSHEncodeEnum;
 use sshwire::{BinString, Blob, TextString};
 use sshwire::{SSHDecode, SSHEncode, SSHSink, SSHSource, WireError, WireResult};
 

--- a/src/sshwire.rs
+++ b/src/sshwire.rs
@@ -338,7 +338,7 @@ impl Debug for BinString<'_> {
 impl SSHEncode for BinString<'_> {
     fn enc(&self, s: &mut dyn SSHSink) -> WireResult<()> {
         (self.0.len() as u32).enc(s)?;
-        self.0.enc(s)
+        s.push(self.0)
     }
 }
 
@@ -427,8 +427,7 @@ impl Display for TextString<'_> {
 
 impl SSHEncode for TextString<'_> {
     fn enc(&self, s: &mut dyn SSHSink) -> WireResult<()> {
-        (self.0.len() as u32).enc(s)?;
-        self.0.enc(s)
+        BinString(self.0).enc(s)
     }
 }
 
@@ -567,7 +566,7 @@ impl SSHEncode for Mpint<'_> {
         if pad {
             0u8.enc(s)?;
         }
-        self.0.enc(s)
+        s.push(self.0)
     }
 }
 
@@ -609,14 +608,6 @@ impl SSHEncode for u32 {
 impl SSHEncode for u64 {
     fn enc(&self, s: &mut dyn SSHSink) -> WireResult<()> {
         s.push(&self.to_be_bytes())
-    }
-}
-
-// no length prefix
-impl SSHEncode for &[u8] {
-    fn enc(&self, s: &mut dyn SSHSink) -> WireResult<()> {
-        // data
-        s.push(self)
     }
 }
 

--- a/src/sshwire.rs
+++ b/src/sshwire.rs
@@ -86,7 +86,7 @@ pub enum WireError {
 
     BadName,
 
-    UnknownVariant,
+    EncodeUnknown,
 
     PacketWrong,
 
@@ -110,9 +110,7 @@ impl From<WireError> for Error {
             WireError::PacketWrong => error::PacketWrong.build(),
             WireError::BadKey => Error::BadKey,
             WireError::BadNumber => Error::BadNumber,
-            WireError::UnknownVariant => {
-                Error::build_bug_msg("Can't encode Unknown")
-            }
+            WireError::EncodeUnknown => Error::build_bug_msg("Can't encode Unknown"),
             WireError::UnknownPacket { number } => Error::UnknownPacket { number },
         }
     }

--- a/src/sshwire.rs
+++ b/src/sshwire.rs
@@ -96,6 +96,8 @@ pub enum WireError {
 
     BadNumber,
 
+    UnknownVariant,
+
     UnknownPacket { number: u8 },
 }
 
@@ -111,6 +113,7 @@ impl From<WireError> for Error {
             WireError::BadKey => Error::BadKey,
             WireError::BadNumber => Error::BadNumber,
             WireError::EncodeUnknown => Error::build_bug_msg("Can't encode Unknown"),
+            WireError::UnknownVariant => Error::UnknownMethod { kind: "" },
             WireError::UnknownPacket { number } => Error::UnknownPacket { number },
         }
     }

--- a/src/sshwire.rs
+++ b/src/sshwire.rs
@@ -12,7 +12,7 @@ use {
 };
 
 use core::convert::AsRef;
-use core::fmt::{Debug, Display};
+use core::fmt::{self, Debug, Display};
 use core::str::FromStr;
 
 use ascii::{AsAsciiStr, AsciiChar, AsciiStr};
@@ -119,6 +119,46 @@ impl From<WireError> for Error {
 }
 
 pub type WireResult<T> = core::result::Result<T, WireError>;
+
+/// Placeholder for unknown variants.
+///
+/// Unknown SSH methods are sometimes non-fatal and
+/// need to be handled by the relevant code, for example newly invented pubkey types.
+/// This is deliberately not `SSHEncode`, we only receive it. sshwire-derive will
+/// automatically create instances.
+#[derive(Clone, PartialEq)]
+pub struct Unknown<'a>(pub &'a [u8]);
+
+impl<'a> Unknown<'a> {
+    pub fn new(u: &'a [u8]) -> Self {
+        let u = Unknown(u);
+        trace!("saw unknown variant \"{u}\"");
+        u
+    }
+}
+
+impl Display for Unknown<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Ok(s) = sshwire::try_as_ascii_str(self.0) {
+            f.write_str(s)
+        } else {
+            write!(f, "non-ascii {:02x?}", self.0)
+        }
+    }
+}
+
+impl Debug for Unknown<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'arb: 'a, 'a> Arbitrary<'arb> for Unknown<'a> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'arb>) -> arbitrary::Result<Self> {
+        Ok(Self(arbitrary::Arbitrary::arbitrary(u)?))
+    }
+}
 
 ///////////////////////////////////////////////
 

--- a/src/sshwire.rs
+++ b/src/sshwire.rs
@@ -161,8 +161,12 @@ pub fn write_ssh(target: &mut [u8], value: &dyn SSHEncode) -> Result<usize> {
 pub fn ssh_push_vec(target: &mut Vec<u8>, value: &dyn SSHEncode) -> Result<()> {
     let orig = target.len();
     let l = length_enc(value)? as usize;
-    target.resize(orig + l, 0);
-    write_ssh(&mut target[orig..], value)?;
+    let l = orig.checked_add(l).ok_or(error::NoRoom.build())?;
+    target.resize(l, 0);
+    let wl = write_ssh(&mut target[orig..], value)
+        // revert length on failure
+        .inspect_err(|_| target.truncate(orig))?;
+    debug_assert_eq!(wl, l);
     Ok(())
 }
 

--- a/src/sshwire.rs
+++ b/src/sshwire.rs
@@ -816,7 +816,7 @@ impl<T: SSHWireDigestUpdate> From<T> for SSHWireDigestTrace<T> {
 impl SSHEncode for rsa::BoxedUint {
     fn enc(&self, s: &mut dyn SSHSink) -> WireResult<()> {
         let b = self.to_be_bytes();
-        Mpint(&b).enc(s)
+        Mpint::new(&b).enc(s)
     }
 }
 

--- a/src/sshwire.rs
+++ b/src/sshwire.rs
@@ -76,7 +76,7 @@ pub trait SSHDecodeEnum<'de>: Sized {
 ///
 /// Compiled code size is very sensitive to the size of this
 /// enum so we avoid unused elements.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum WireError {
     NoRoom,
 

--- a/src/sshwire.rs
+++ b/src/sshwire.rs
@@ -707,6 +707,23 @@ impl<'de, const N: usize> SSHDecode<'de> for heapless::String<N> {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl SSHEncode for alloc::string::String {
+    fn enc(&self, s: &mut dyn SSHSink) -> WireResult<()> {
+        self.as_str().enc(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'de> SSHDecode<'de> for alloc::string::String {
+    fn dec<S>(s: &mut S) -> WireResult<Self>
+    where
+        S: SSHSource<'de>,
+    {
+        Ok(<&str>::dec(s)?.into())
+    }
+}
+
 /// Like `digest::DynDigest` but simpler.
 ///
 /// Doesn't have any optional methods that depend on `alloc`.

--- a/src/sshwire.rs
+++ b/src/sshwire.rs
@@ -98,6 +98,8 @@ pub enum WireError {
 
     UnknownVariant,
 
+    SSHProtoUnsupported,
+
     UnknownPacket { number: u8 },
 }
 
@@ -114,6 +116,7 @@ impl From<WireError> for Error {
             WireError::BadNumber => Error::BadNumber,
             WireError::EncodeUnknown => Error::build_bug_msg("Can't encode Unknown"),
             WireError::UnknownVariant => Error::UnknownMethod { kind: "" },
+            WireError::SSHProtoUnsupported => Error::SSHProtoUnsupported,
             WireError::UnknownPacket { number } => Error::UnknownPacket { number },
         }
     }

--- a/sshwire-derive/Cargo.toml
+++ b/sshwire-derive/Cargo.toml
@@ -11,3 +11,6 @@ proc-macro = true
 
 [dependencies]
 virtue = "=0.0.17" # Last released version
+
+[dev-dependencies]
+sunset = { workspace = true, features = ["std"]}

--- a/sshwire-derive/src/lib.rs
+++ b/sshwire-derive/src/lib.rs
@@ -76,8 +76,10 @@ enum FieldAtt {
     /// eg `#[sshwire(variant_name = ch)]` for `ChannelRequest`
     VariantName(Ident),
 
-    /// Any unknown variant name should be recorded here.
-    /// This variant can't be written out.
+    /// Any unknown variant name.
+    ///
+    /// This variant can't be written out. It can be either a tuple enum variant
+    /// `EnumName::Unknown(Unknown<'a>)` or a unit variant `EnumName::Unknown`.
     /// `#[sshwire(unknown))]`
     CaptureUnknown,
 
@@ -295,6 +297,9 @@ fn encode_enum(
                     match &var.fields {
                         None => {
                             // Unit enum
+                            if atts.iter().any(|a| matches!(a, FieldAtt::CaptureUnknown)) {
+                                rhs.push_parsed("return Err(::sunset::sshwire::WireError::UnknownVariant)")?;
+                            }
                         }
                         Some(Fields::Tuple(f)) => {
                             match_arm.group(Delimiter::Parenthesis, |item| {
@@ -603,12 +608,22 @@ fn decode_enum_names(
                         have_unknown_variant = true;
                         // create the Unknown fallthrough but it will be at the end of the match list
                         let mut m = StreamBuilder::new();
-                        m.push_parsed(format!("_ => {{ s.ctx().seen_unknown = true; Self::{}(::sunset::packets::Unknown::new(variant))}}", var.name))?;
+
+                        match var.fields {
+                            Some(Fields::Tuple(ref f)) if f.len() == 1 => {
+                                m.push_parsed(format!("_ => {{ s.ctx().seen_unknown = true; Self::{}(::sunset::packets::Unknown::new(variant)) }}", var.name))?;
+                            }
+                            None => {
+                                m.push_parsed(format!("_ => {{ s.ctx().seen_unknown = true; Self::{} }}", var.name))?;
+                            }
+                            _ => {
+                                return Err(Error::Custom {
+                                    error: "#[sshwire(unknown)] must be a single field tuple variant, or unit variant".into(), span: None})
+                            }
+                        }
+
                         if unknown_arm.replace(m).is_some() {
                             return Err(Error::Custom { error: "only one variant can have #[sshwire(unknown)]".into(), span: None})
-                        }
-                        if !matches!(var.fields, Some(Fields::Tuple(ref f)) if f.len() == 1) {
-                            return Err(Error::Custom { error: "#[sshwire(unknown)] must be a single field tuple variant".into(), span: None})
                         }
                     } else {
                         let var_name = field_att_var_name(&var.name, atts)?;

--- a/sshwire-derive/src/lib.rs
+++ b/sshwire-derive/src/lib.rs
@@ -67,6 +67,10 @@ enum ContainerAtt {
     /// Don't generate SSHEncodeEnum. Can't be used with SSHDecode derive.
     /// `#[sshwire(no_variant_names)]`
     NoNames,
+
+    /// Decoding unknown variants should fail with an error.
+    /// `#[sshwire(decode_unknown_fail)]`
+    DecodeUnknownFail,
 }
 
 /// Field attributes.
@@ -106,6 +110,11 @@ fn take_cont_atts(atts: &[Attribute]) -> Result<Vec<ContainerAtt>> {
                 }
                 ParsedAttribute::Tag(l) if l.to_string() == "variant_prefix" => {
                     Ok(ContainerAtt::VariantPrefix)
+                }
+                ParsedAttribute::Tag(l)
+                    if l.to_string() == "decode_unknown_fail" =>
+                {
+                    Ok(ContainerAtt::DecodeUnknownFail)
                 }
                 _ => Err(Error::Custom {
                     error: "Unknown sshwire atttribute".into(),
@@ -536,12 +545,15 @@ fn decode_enum(
         });
     }
 
+    let decode_unknown_fail =
+        cont_atts.iter().any(|c| matches!(c, ContainerAtt::DecodeUnknownFail));
+
     // SSHDecode trait if it is self describing
     if cont_atts.iter().any(|c| matches!(c, ContainerAtt::VariantPrefix)) {
         decode_enum_variant_prefix(gn, atts, &body)?;
     }
 
-    decode_enum_names(gn, atts, &body)?;
+    decode_enum_names(gn, atts, &body, decode_unknown_fail)?;
     Ok(())
 }
 
@@ -577,10 +589,13 @@ fn decode_enum_variant_prefix(
 /// Generate `SSHDecodeEnum` implementation.
 ///
 /// `dec_enum()` takes a variant name argument, used to choose the variant to decode.
+/// If `decode_unknown_fail` is set, on unknown name instead of using #[sshwire(unknown)] variant,
+/// it will return WireError::UnknownVariant
 fn decode_enum_names(
     gn: &mut Generator,
     _atts: &[Attribute],
     body: &EnumBody,
+    decode_unknown_fail: bool,
 ) -> Result<()> {
     gn.impl_for_with_lifetimes("::sunset::sshwire::SSHDecodeEnum", ["de"])
         .modify_generic_constraints(|generics, where_constraints| {
@@ -601,6 +616,7 @@ fn decode_enum_names(
 
             fn_body.push_parsed("let r = match var_str")?;
             fn_body.group(Delimiter::Brace, |match_arm| {
+
                 let mut unknown_arm = None;
                 for var in &body.variants {
                     let atts = take_field_atts(&var.attributes)?;
@@ -623,7 +639,7 @@ fn decode_enum_names(
                         }
 
                         if unknown_arm.replace(m).is_some() {
-                            return Err(Error::Custom { error: "only one variant can have #[sshwire(unknown)]".into(), span: None})
+                            return Err(Error::Custom { error: "can have one field #[sshwire(unknown)], or enum att #[sshwire(decode_unknown_fail)]".into(), span: None})
                         }
                     } else {
                         let var_name = field_att_var_name(&var.name, atts)?;
@@ -661,12 +677,16 @@ fn decode_enum_names(
                         match_arm.append(unk);
                     }
                 }
+
+                if decode_unknown_fail {
+                    match_arm.push_parsed("_ => { return Err(::sunset::sshwire::WireError::UnknownVariant); }")?;
+                }
                 Ok(())
             })?;
             fn_body.push_parsed("; Ok(r)")?;
 
-            if !have_unknown_variant {
-                return Err(Error::Custom { error: "SSHDecode enum needs a #[sshwire(unknown) variant".into(), span: None});
+            if !(have_unknown_variant || decode_unknown_fail) {
+                return Err(Error::Custom { error: "SSHDecode enum needs a #[sshwire(unknown)] variant".into(), span: None});
             }
 
             Ok(())

--- a/sshwire-derive/src/lib.rs
+++ b/sshwire-derive/src/lib.rs
@@ -292,19 +292,25 @@ fn encode_enum(
                         None => {
                             // Unit enum
                         }
-                        Some(Fields::Tuple(ref f)) if f.len() == 1 => {
+                        Some(Fields::Tuple(ref f)) => {
                             match_arm.group(Delimiter::Parenthesis, |item| {
-                                item.ident_str("ref");
-                                item.ident_str("i");
+                                for i in 0..f.len() {
+                                    item.ident_str("ref");
+                                    item.ident_str(format!("f{i}"));
+                                    item.punct(',');
+                                }
                                 Ok(())
                             })?;
                             if atts.iter().any(|a| matches!(a, FieldAtt::CaptureUnknown)) {
                                 rhs.push_parsed("return Err(::sunset::sshwire::WireError::UnknownVariant)")?;
                             } else {
-                                rhs.push_parsed(format!("::sunset::sshwire::SSHEncode::enc(i, s)?;"))?;
+                                for i in 0..f.len() {
+                                    rhs.push_parsed(format!("::sunset::sshwire::SSHEncode::enc(f{i}, s)?;"))?;
+                                }
                             }
 
                         }
+                        // Some(Fields::)
                         _ => return Err(Error::Custom { error: "sunset_sshwire_derive::SSHEncode currently only implements Unit or single value enum variants.".into(), span: None})
                     }
 
@@ -376,9 +382,12 @@ fn encode_enum_names(
                         None => {
                             // nothing to do
                         }
-                        Some(Fields::Tuple(ref f)) if f.len() == 1 => {
+                        Some(Fields::Tuple(ref f)) => {
                             match_arm.group(Delimiter::Parenthesis, |item| {
-                                item.ident_str("_");
+                                for _ in f {
+                                    item.ident_str("_");
+                                    item.punct(',');
+                                }
                                 Ok(())
                             })?;
 
@@ -542,6 +551,7 @@ fn decode_enum_names(
         .with_arg("variant", "&'de [u8]")
         .with_return_type("::sunset::sshwire::WireResult<Self>")
         .body(|fn_body| {
+            let mut have_unknown_variant = false;
             // Some(ascii_string), or None
             fn_body.push_parsed("let var_str = ::sunset::sshwire::try_as_ascii_str(variant).ok();")?;
 
@@ -551,11 +561,15 @@ fn decode_enum_names(
                 for var in &body.variants {
                     let atts = take_field_atts(&var.attributes)?;
                     if atts.iter().any(|a| matches!(a, FieldAtt::CaptureUnknown)) {
+                        have_unknown_variant = true;
                         // create the Unknown fallthrough but it will be at the end of the match list
                         let mut m = StreamBuilder::new();
-                        m.push_parsed(format!("_ => {{ s.ctx().seen_unknown = true; Self::{}(Unknown::new(variant))}}", var.name))?;
+                        m.push_parsed(format!("_ => {{ s.ctx().seen_unknown = true; Self::{}(::sunset::packets::Unknown::new(variant))}}", var.name))?;
                         if unknown_arm.replace(m).is_some() {
                             return Err(Error::Custom { error: "only one variant can have #[sshwire(unknown)]".into(), span: None})
+                        }
+                        if !matches!(var.fields, Some(Fields::Tuple(ref f)) if f.len() == 1) {
+                            return Err(Error::Custom { error: "#[sshwire(unknown)] must be a single field tuple variant".into(), span: None})
                         }
                     } else {
                         let var_name = field_att_var_names(&var.name, atts)?;
@@ -565,10 +579,16 @@ fn decode_enum_names(
                                 None => {
                                     var_body.push_parsed(format!("Self::{}", var.name))?;
                                 }
-                                Some(Fields::Tuple(ref f)) if f.len() == 1 => {
-                                    var_body.push_parsed(format!("Self::{}(::sunset::sshwire::SSHDecode::dec(s)?)", var.name))?;
+                                Some(Fields::Tuple(ref f)) => {
+                                    var_body.push_parsed(format!("Self::{}", var.name))?;
+                                    var_body.group(Delimiter::Parenthesis, |b| {
+                                        for _ in f {
+                                            b.push_parsed("::sunset::sshwire::SSHDecode::dec(s)?,")?;
+                                        }
+                                        Ok(())
+                                    })?;
                                 }
-                            _ => return Err(Error::Custom { error: "SSHDecode currently only implements Unit or single value enum variants. ".into(), span: None})
+                                _ => return Err(Error::Custom { error: "SSHDecode currently only implements Unit or single value enum variants. ".into(), span: None})
                             }
                             Ok(())
                         })?;
@@ -581,6 +601,11 @@ fn decode_enum_names(
                 Ok(())
             })?;
             fn_body.push_parsed("; Ok(r)")?;
+
+            if !have_unknown_variant {
+                return Err(Error::Custom { error: "SSHDecode enum needs #[sshwire(unknown) variant".into(), span: None});
+            }
+
             Ok(())
         })?;
     Ok(())

--- a/sshwire-derive/src/lib.rs
+++ b/sshwire-derive/src/lib.rs
@@ -298,7 +298,7 @@ fn encode_enum(
                         None => {
                             // Unit enum
                             if atts.iter().any(|a| matches!(a, FieldAtt::CaptureUnknown)) {
-                                rhs.push_parsed("return Err(::sunset::sshwire::WireError::UnknownVariant)")?;
+                                rhs.push_parsed("return Err(::sunset::sshwire::WireError::EncodeUnknown)")?;
                             }
                         }
                         Some(Fields::Tuple(f)) => {
@@ -314,7 +314,7 @@ fn encode_enum(
                                 if f.len() != 1 {
                                     return Err(Error::Custom { error: "sshwire(unknown) needs to be a single field tuple variant".into(), span: Some(var.name.span())})
                                 }
-                                rhs.push_parsed("return Err(::sunset::sshwire::WireError::UnknownVariant)")?;
+                                rhs.push_parsed("return Err(::sunset::sshwire::WireError::EncodeUnknown)")?;
                             } else {
                                 for i in 0..f.len() {
                                     rhs.push_parsed(format!("::sunset::sshwire::SSHEncode::enc(f{i}, s)?;"))?;
@@ -404,7 +404,7 @@ fn encode_enum_names(
                     let mut rhs = StreamBuilder::new();
                     let atts = take_field_atts(&var.attributes)?;
                     if atts.iter().any(|a| matches!(a, FieldAtt::CaptureUnknown)) {
-                        rhs.push_parsed("return Err(::sunset::sshwire::WireError::UnknownVariant)")?;
+                        rhs.push_parsed("return Err(::sunset::sshwire::WireError::EncodeUnknown)")?;
                     } else {
                         rhs.push(field_att_var_name(&var.name, atts)?);
                     }

--- a/sshwire-derive/src/lib.rs
+++ b/sshwire-derive/src/lib.rs
@@ -229,6 +229,7 @@ fn encode_struct(gn: &mut Generator, body: StructBody) -> Result<()> {
                     }
                 }
                 Some(Fields::Struct(v)) => {
+                    fn_body.push_parsed(format!("use ::sunset::sshwire::SSHEncodeEnum;"))?;
                     for f in v {
                         let fname = &f.0;
                         let atts = take_field_atts(&f.1.attributes)?;
@@ -268,6 +269,7 @@ fn encode_enum(
         .with_return_type("::sunset::sshwire::WireResult<()>")
         .body(|fn_body| {
             if cont_atts.iter().any(|c| matches!(c, ContainerAtt::VariantPrefix)) {
+                fn_body.push_parsed(format!("use ::sunset::sshwire::SSHEncodeEnum;"))?;
                 fn_body.push_parsed("::sunset::sshwire::SSHEncode::enc(&self.variant_name()?, s)?;")?;
             }
 
@@ -288,11 +290,11 @@ fn encode_enum(
                         // Could be implemented if needed.
                         return Err(Error::Custom { error: "sunset_sshwire_derive::SSHEncode currently does not encode enum discriminants.".into(), span: Some(val.span())})
                     }
-                    match var.fields {
+                    match &var.fields {
                         None => {
                             // Unit enum
                         }
-                        Some(Fields::Tuple(ref f)) => {
+                        Some(Fields::Tuple(f)) => {
                             match_arm.group(Delimiter::Parenthesis, |item| {
                                 for i in 0..f.len() {
                                     item.ident_str("ref");
@@ -302,6 +304,9 @@ fn encode_enum(
                                 Ok(())
                             })?;
                             if atts.iter().any(|a| matches!(a, FieldAtt::CaptureUnknown)) {
+                                if f.len() != 1 {
+                                    return Err(Error::Custom { error: "sshwire(unknown) needs to be a single field tuple variant".into(), span: Some(var.name.span())})
+                                }
                                 rhs.push_parsed("return Err(::sunset::sshwire::WireError::UnknownVariant)")?;
                             } else {
                                 for i in 0..f.len() {
@@ -310,8 +315,22 @@ fn encode_enum(
                             }
 
                         }
-                        // Some(Fields::)
-                        _ => return Err(Error::Custom { error: "sunset_sshwire_derive::SSHEncode currently only implements Unit or single value enum variants.".into(), span: None})
+                        Some(Fields::Struct(f)) => {
+                            if atts.iter().any(|a| matches!(a, FieldAtt::CaptureUnknown)) {
+                                return Err(Error::Custom { error: "sshwire(unknown) can't be a struct variant".into(), span: Some(var.name.span())})
+                            }
+                            match_arm.group(Delimiter::Brace, |item| {
+                                for (id, _) in f {
+                                    item.ident_str("ref");
+                                    item.ident(id.clone());
+                                    item.punct(',');
+                                }
+                                Ok(())
+                            })?;
+                            for (id, _) in f {
+                                rhs.push_parsed(format!("::sunset::sshwire::SSHEncode::enc({id}, s)?;"))?;
+                            }
+                        }
                     }
 
                     match_arm.puncts("=>");
@@ -392,7 +411,12 @@ fn encode_enum_names(
                             })?;
 
                         }
-                        _ => return Err(Error::Custom { error: "sunset_sshwire_derive::SSHEncode currently only implements Unit or single value enum variants.".into(), span: None})
+                        Some(Fields::Struct(_)) => {
+                            match_arm.group(Delimiter::Brace, |item| {
+                                item.puncts("..");
+                                Ok(())
+                            })?;
+                        }
                     }
 
                     match_arm.puncts("=>");
@@ -575,11 +599,11 @@ fn decode_enum_names(
                         let var_name = field_att_var_names(&var.name, atts)?;
                         match_arm.push_parsed(format!("Some({}) => ", var_name))?;
                         match_arm.group(Delimiter::Brace, |var_body| {
-                            match var.fields {
+                            match &var.fields {
                                 None => {
                                     var_body.push_parsed(format!("Self::{}", var.name))?;
                                 }
-                                Some(Fields::Tuple(ref f)) => {
+                                Some(Fields::Tuple(f)) => {
                                     var_body.push_parsed(format!("Self::{}", var.name))?;
                                     var_body.group(Delimiter::Parenthesis, |b| {
                                         for _ in f {
@@ -588,7 +612,16 @@ fn decode_enum_names(
                                         Ok(())
                                     })?;
                                 }
-                                _ => return Err(Error::Custom { error: "SSHDecode currently only implements Unit or single value enum variants. ".into(), span: None})
+                                Some(Fields::Struct(f)) => {
+                                    var_body.push_parsed(format!("Self::{}", var.name))?;
+                                    var_body.group(Delimiter::Brace, |b| {
+                                        for (id, _) in f {
+                                            b.push_parsed(format!("{}: ::sunset::sshwire::SSHDecode::dec(s)?,", id))?;
+                                        }
+                                        Ok(())
+                                    })?;
+
+                                }
                             }
                             Ok(())
                         })?;

--- a/sshwire-derive/src/lib.rs
+++ b/sshwire-derive/src/lib.rs
@@ -611,7 +611,7 @@ fn decode_enum_names(
 
                         match var.fields {
                             Some(Fields::Tuple(ref f)) if f.len() == 1 => {
-                                m.push_parsed(format!("_ => {{ s.ctx().seen_unknown = true; Self::{}(::sunset::packets::Unknown::new(variant)) }}", var.name))?;
+                                m.push_parsed(format!("_ => {{ s.ctx().seen_unknown = true; Self::{}(::sunset::sshwire::Unknown::new(variant)) }}", var.name))?;
                             }
                             None => {
                                 m.push_parsed(format!("_ => {{ s.ctx().seen_unknown = true; Self::{} }}", var.name))?;

--- a/sshwire-derive/src/lib.rs
+++ b/sshwire-derive/src/lib.rs
@@ -1,7 +1,7 @@
 //! Used in conjunction with `sshwire.rs` and `packets.rs`
 //!
 //! `SSHWIRE_DEBUG` environment variable can be set at build time
-//! to write generated files to the `target/` directory.
+//! to write generated files to the `target/generated` directory.
 #![expect(clippy::useless_format)]
 
 use std::collections::HashSet;
@@ -28,39 +28,36 @@ pub fn derive_decode(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 fn encode_inner(input: TokenStream) -> Result<TokenStream> {
     let parse = Parse::new(input)?;
     let (mut gn, att, body) = parse.into_generator();
-    // println!("att {att:#?}");
-    match body {
-        Body::Struct(body) => {
-            encode_struct(&mut gn, body)?;
-        }
-        Body::Enum(body) => {
-            encode_enum(&mut gn, &att, body)?;
-        }
-    }
+    let err = match body {
+        Body::Struct(body) => encode_struct(&mut gn, body),
+        Body::Enum(body) => encode_enum(&mut gn, &att, body),
+    };
     if env::var(ENV_SSHWIRE_DEBUG).is_ok() {
         gn.export_to_file("sshwire", "SSHEncode");
     }
-    gn.finish()
+    // .finish() needs to call even if we return another error
+    let toks = gn.finish();
+    err?;
+    toks
 }
 
 fn decode_inner(input: TokenStream) -> Result<TokenStream> {
     let parse = Parse::new(input)?;
     let (mut gn, att, body) = parse.into_generator();
-    // println!("att {att:#?}");
-    match body {
-        Body::Struct(body) => {
-            decode_struct(&mut gn, body)?;
-        }
-        Body::Enum(body) => {
-            decode_enum(&mut gn, &att, body)?;
-        }
-    }
+    let err = match body {
+        Body::Struct(body) => decode_struct(&mut gn, body),
+        Body::Enum(body) => decode_enum(&mut gn, &att, body),
+    };
     if env::var(ENV_SSHWIRE_DEBUG).is_ok() {
         gn.export_to_file("sshwire", "SSHDecode");
     }
-    gn.finish()
+    // .finish() needs to call even if we return another error
+    let toks = gn.finish();
+    err?;
+    toks
 }
 
+/// Struct/Enum attributes.
 #[derive(Debug)]
 enum ContainerAtt {
     /// The string of the method is prefixed to this enum.
@@ -72,6 +69,7 @@ enum ContainerAtt {
     NoNames,
 }
 
+/// Field attributes.
 #[derive(Debug)]
 enum FieldAtt {
     /// A variant method name will be encoded/decoded before the next field.
@@ -90,6 +88,7 @@ enum FieldAtt {
     Variant(TokenTree),
 }
 
+/// Parses `sshwire` struct/enum attributes.
 fn take_cont_atts(atts: &[Attribute]) -> Result<Vec<ContainerAtt>> {
     let x = atts
         .iter()
@@ -117,6 +116,7 @@ fn take_cont_atts(atts: &[Attribute]) -> Result<Vec<ContainerAtt>> {
     Ok(ret)
 }
 
+/// Parses `sshwire` field attributes.
 // TODO: we could use virtue parse_tagged_attribute() though it doesn't support Literals
 fn take_field_atts(atts: &[Attribute]) -> Result<Vec<FieldAtt>> {
     atts.iter()
@@ -211,6 +211,7 @@ fn take_field_atts(atts: &[Attribute]) -> Result<Vec<FieldAtt>> {
         .collect()
 }
 
+/// Generates `SSHEncode` for a struct.
 fn encode_struct(gn: &mut Generator, body: StructBody) -> Result<()> {
     gn.impl_for("::sunset::sshwire::SSHEncode")
         .generate_fn("enc")
@@ -255,6 +256,7 @@ fn encode_struct(gn: &mut Generator, body: StructBody) -> Result<()> {
     Ok(())
 }
 
+/// Generates `SSHEncode` and `SSHEncodeEnum` for an enum where required.
 fn encode_enum(
     gn: &mut Generator,
     atts: &[Attribute],
@@ -353,7 +355,11 @@ fn encode_enum(
     Ok(())
 }
 
-fn field_att_var_names(name: &Ident, mut atts: Vec<FieldAtt>) -> Result<TokenTree> {
+/// Retrieves the variant name for a field.
+///
+/// This is the `...` from `#[sshwire(variant = ...)]`, may be a
+/// string literal or a `const` `&str`.
+fn field_att_var_name(name: &Ident, mut atts: Vec<FieldAtt>) -> Result<TokenTree> {
     let mut v = vec![];
     while let Some(p) = atts.pop() {
         if let FieldAtt::Variant(t) = p {
@@ -372,6 +378,7 @@ fn field_att_var_names(name: &Ident, mut atts: Vec<FieldAtt>) -> Result<TokenTre
     Ok(v.pop().unwrap())
 }
 
+/// Generates `SSHEncodeEnum` for an enum
 fn encode_enum_names(
     gn: &mut Generator,
     _atts: &[Attribute],
@@ -394,7 +401,7 @@ fn encode_enum_names(
                     if atts.iter().any(|a| matches!(a, FieldAtt::CaptureUnknown)) {
                         rhs.push_parsed("return Err(::sunset::sshwire::WireError::UnknownVariant)")?;
                     } else {
-                        rhs.push(field_att_var_names(&var.name, atts)?);
+                        rhs.push(field_att_var_name(&var.name, atts)?);
                     }
 
                     match var.fields {
@@ -438,6 +445,7 @@ fn encode_enum_names(
     Ok(())
 }
 
+/// Generates SSHDecode for a struct.
 fn decode_struct(gn: &mut Generator, body: StructBody) -> Result<()> {
     gn.impl_for_with_lifetimes("::sunset::sshwire::SSHDecode", ["de"])
         .modify_generic_constraints(|generics, where_constraints| {
@@ -506,6 +514,7 @@ fn decode_struct(gn: &mut Generator, body: StructBody) -> Result<()> {
     Ok(())
 }
 
+/// Generates `SSHDecode` and `SSHDecodeEnum` for an enum where required.
 fn decode_enum(
     gn: &mut Generator,
     atts: &[Attribute],
@@ -531,6 +540,9 @@ fn decode_enum(
     Ok(())
 }
 
+/// Generate `SSHDecode` implementation.
+///
+/// Reads the variant name from the wire, then calls `dec_enum()` with that variant name.
 fn decode_enum_variant_prefix(
     gn: &mut Generator,
     _atts: &[Attribute],
@@ -557,6 +569,9 @@ fn decode_enum_variant_prefix(
         })
 }
 
+/// Generate `SSHDecodeEnum` implementation.
+///
+/// `dec_enum()` takes a variant name argument, used to choose the variant to decode.
 fn decode_enum_names(
     gn: &mut Generator,
     _atts: &[Attribute],
@@ -596,7 +611,7 @@ fn decode_enum_names(
                             return Err(Error::Custom { error: "#[sshwire(unknown)] must be a single field tuple variant".into(), span: None})
                         }
                     } else {
-                        let var_name = field_att_var_names(&var.name, atts)?;
+                        let var_name = field_att_var_name(&var.name, atts)?;
                         match_arm.push_parsed(format!("Some({}) => ", var_name))?;
                         match_arm.group(Delimiter::Brace, |var_body| {
                             match &var.fields {
@@ -636,7 +651,7 @@ fn decode_enum_names(
             fn_body.push_parsed("; Ok(r)")?;
 
             if !have_unknown_variant {
-                return Err(Error::Custom { error: "SSHDecode enum needs #[sshwire(unknown) variant".into(), span: None});
+                return Err(Error::Custom { error: "SSHDecode enum needs a #[sshwire(unknown) variant".into(), span: None});
             }
 
             Ok(())

--- a/sshwire-derive/tests/test.rs
+++ b/sshwire-derive/tests/test.rs
@@ -1,0 +1,30 @@
+use sunset::packets::Unknown;
+use sunset::sshwire::{read_ssh, ssh_push_vec};
+use sunset_sshwire_derive::*;
+
+#[test]
+fn enum_tuple() {
+    #[derive(SSHEncode, SSHDecode, PartialEq, Debug)]
+    enum En<'a> {
+        #[sshwire(variant = "a")]
+        A,
+        #[sshwire(variant = "b")]
+        B(u32, u8),
+        #[sshwire(variant = "c")]
+        C(bool),
+        #[sshwire(unknown)]
+        U(Unknown<'a>),
+    }
+
+    let mut v = vec![];
+    ssh_push_vec(&mut v, &En::A).unwrap();
+    assert!(v.is_empty());
+
+    let mut v = vec![];
+    ssh_push_vec(&mut v, &En::B(0xa1, 0x20)).unwrap();
+    assert_eq!(v, [0x00u8, 0x00, 0x00, 0xa1, 0x20]);
+
+    let mut v = vec![];
+    ssh_push_vec(&mut v, &En::C(true)).unwrap();
+    assert_eq!(v, [0x01u8]);
+}

--- a/sshwire-derive/tests/test.rs
+++ b/sshwire-derive/tests/test.rs
@@ -54,6 +54,36 @@ fn unknown_variant() {
 }
 
 #[test]
+fn no_unknown_variant() {
+    #[derive(SSHEncode, SSHDecode, PartialEq, Debug)]
+    #[sshwire(variant_prefix)]
+    #[sshwire(decode_unknown_fail)]
+    enum En {
+        #[sshwire(variant = "a")]
+        A,
+        #[sshwire(variant = "b")]
+        B(u32, u8),
+        #[sshwire(variant = "c")]
+        C,
+    }
+
+    let s = [0x00u8, 0x00, 0x00, 0x02, b'X', b'X'];
+    let r = read_ssh::<En>(&s, None);
+    assert!(
+        matches!(r, Err(sunset::Error::UnknownMethod { .. })),
+        "Unexpected {r:?}"
+    );
+
+    let s = [0x00u8, 0x00, 0x00, 0x01, b'a'];
+    let r = read_ssh::<En>(&s, None);
+    assert!(matches!(r, Ok((En::A, 5))), "Unexpected {r:?}");
+
+    let s = [0x00u8, 0x00, 0x00, 0x01, b'c'];
+    let r = read_ssh::<En>(&s, None);
+    assert!(matches!(r, Ok((En::C, 5))), "Unexpected {r:?}");
+}
+
+#[test]
 fn unknown_unit_variant() {
     #[derive(SSHEncode, SSHDecode, PartialEq, Debug)]
     #[sshwire(variant_prefix)]

--- a/sshwire-derive/tests/test.rs
+++ b/sshwire-derive/tests/test.rs
@@ -1,7 +1,6 @@
-use sunset::packets::{ParseContext, Unknown};
-use sunset::sshwire::{self, SSHDecodeEnum, read_ssh, ssh_push_vec};
+use sunset::packets::Unknown;
+use sunset::sshwire::{read_ssh, ssh_push_vec};
 use sunset_sshwire_derive::*;
-use virtue::parse::Parse;
 
 #[test]
 fn enum_tuple() {

--- a/sshwire-derive/tests/test.rs
+++ b/sshwire-derive/tests/test.rs
@@ -50,7 +50,7 @@ fn unknown_variant() {
 
     // encoding fails
     let e = sshwire::length_enc(&r);
-    assert_eq!(e, Err(WireError::UnknownVariant));
+    assert_eq!(e, Err(WireError::EncodeUnknown));
 }
 
 #[test]
@@ -73,7 +73,7 @@ fn unknown_unit_variant() {
 
     // encoding fails
     let e = sshwire::length_enc(&En::U);
-    assert_eq!(e, Err(WireError::UnknownVariant));
+    assert_eq!(e, Err(WireError::EncodeUnknown));
 }
 
 #[test]

--- a/sshwire-derive/tests/test.rs
+++ b/sshwire-derive/tests/test.rs
@@ -1,5 +1,5 @@
 use sunset::packets::Unknown;
-use sunset::sshwire::{read_ssh, ssh_push_vec};
+use sunset::sshwire::{self, WireError, read_ssh, ssh_push_vec};
 use sunset_sshwire_derive::*;
 
 #[test]
@@ -31,7 +31,7 @@ fn enum_tuple() {
 }
 
 #[test]
-fn decode_unknown() {
+fn unknown_variant() {
     #[derive(SSHEncode, SSHDecode, PartialEq, Debug)]
     #[sshwire(variant_prefix)]
     enum En<'a> {
@@ -47,6 +47,33 @@ fn decode_unknown() {
     let (r, l) = read_ssh::<En>(&s, None).unwrap();
     assert_eq!(l, s.len());
     assert_eq!(r, En::U(Unknown(b"XX")));
+
+    // encoding fails
+    let e = sshwire::length_enc(&r);
+    assert_eq!(e, Err(WireError::UnknownVariant));
+}
+
+#[test]
+fn unknown_unit_variant() {
+    #[derive(SSHEncode, SSHDecode, PartialEq, Debug)]
+    #[sshwire(variant_prefix)]
+    enum En {
+        #[sshwire(variant = "a")]
+        A,
+        #[sshwire(variant = "b")]
+        B(u32, u8),
+        #[sshwire(unknown)]
+        U,
+    }
+
+    let s = [0x00u8, 0x00, 0x00, 0x02, b'X', b'X'];
+    let (r, l) = read_ssh::<En>(&s, None).unwrap();
+    assert_eq!(l, s.len());
+    assert_eq!(r, En::U);
+
+    // encoding fails
+    let e = sshwire::length_enc(&En::U);
+    assert_eq!(e, Err(WireError::UnknownVariant));
 }
 
 #[test]

--- a/sshwire-derive/tests/test.rs
+++ b/sshwire-derive/tests/test.rs
@@ -1,10 +1,12 @@
-use sunset::packets::Unknown;
-use sunset::sshwire::{read_ssh, ssh_push_vec};
+use sunset::packets::{ParseContext, Unknown};
+use sunset::sshwire::{self, SSHDecodeEnum, read_ssh, ssh_push_vec};
 use sunset_sshwire_derive::*;
+use virtue::parse::Parse;
 
 #[test]
 fn enum_tuple() {
     #[derive(SSHEncode, SSHDecode, PartialEq, Debug)]
+    #[sshwire(variant_prefix)]
     enum En<'a> {
         #[sshwire(variant = "a")]
         A,
@@ -18,13 +20,56 @@ fn enum_tuple() {
 
     let mut v = vec![];
     ssh_push_vec(&mut v, &En::A).unwrap();
-    assert!(v.is_empty());
+    assert_eq!(v, [0x00u8, 0, 0, 1, b'a']);
 
     let mut v = vec![];
     ssh_push_vec(&mut v, &En::B(0xa1, 0x20)).unwrap();
-    assert_eq!(v, [0x00u8, 0x00, 0x00, 0xa1, 0x20]);
+    assert_eq!(v, [0x00u8, 0, 0, 1, b'b', 0x00u8, 0x00, 0x00, 0xa1, 0x20]);
 
     let mut v = vec![];
     ssh_push_vec(&mut v, &En::C(true)).unwrap();
-    assert_eq!(v, [0x01u8]);
+    assert_eq!(v, [0x00u8, 0, 0, 1, b'c', 0x01]);
+}
+
+#[test]
+fn decode_unknown() {
+    #[derive(SSHEncode, SSHDecode, PartialEq, Debug)]
+    #[sshwire(variant_prefix)]
+    enum En<'a> {
+        #[sshwire(variant = "a")]
+        A,
+        #[sshwire(variant = "b")]
+        B(u32, u8),
+        #[sshwire(unknown)]
+        U(Unknown<'a>),
+    }
+
+    let s = [0x00u8, 0x00, 0x00, 0x02, b'X', b'X'];
+    let (r, l) = read_ssh::<En>(&s, None).unwrap();
+    assert_eq!(l, s.len());
+    assert_eq!(r, En::U(Unknown(b"XX")));
+}
+
+#[test]
+fn enum_struct() {
+    #[derive(SSHEncode, SSHDecode, PartialEq, Debug)]
+    #[sshwire(variant_prefix)]
+    enum En<'a> {
+        #[sshwire(variant = "a")]
+        A,
+        #[sshwire(variant = "b")]
+        B { first: u32, second: u8 },
+        #[sshwire(variant = "c")]
+        C { one: bool },
+        #[sshwire(unknown)]
+        U(Unknown<'a>),
+    }
+
+    let mut v = vec![];
+    ssh_push_vec(&mut v, &En::B { first: 0xa1, second: 0x20 }).unwrap();
+    assert_eq!(v, [0x00u8, 0x00, 0x00, 0x01, b'b', 0x00, 0x00, 0x00, 0xa1, 0x20]);
+
+    let mut v = vec![];
+    ssh_push_vec(&mut v, &En::C { one: true }).unwrap();
+    assert_eq!(v, [0x00u8, 0x00, 0x00, 0x01, b'c', 0x01]);
 }

--- a/sshwire-derive/tests/test.rs
+++ b/sshwire-derive/tests/test.rs
@@ -1,4 +1,4 @@
-use sunset::packets::Unknown;
+use sunset::sshwire::Unknown;
 use sunset::sshwire::{self, WireError, read_ssh, ssh_push_vec};
 use sunset_sshwire_derive::*;
 


### PR DESCRIPTION
sshwire-derive can now encode enum tuple and struct variants. These aren't currently used in SSH protocol, but can be used in future for inter-application encoding.

Handling of unknown variants has changed, with a new `sshwire(decode_unknown_fail)` attribute to return an error, so enums don't need an `Unknown` variant. `Error::UnknownVariant` now has a different meaning, `EncodeUnknown` is the name for the old error.

`&[u8]` no longer has SSHEncode since it could be unclear what it would do.